### PR TITLE
Fix C++11 support in CMake and headers.

### DIFF
--- a/control/src/Simulation/ControlSimulation_impl.hpp
+++ b/control/src/Simulation/ControlSimulation_impl.hpp
@@ -28,8 +28,11 @@
 
 #include "SimulationTypeDef.hpp"
 
-
-#if (__cplusplus >= 201103L)
+#include <SiconosConfig.h>
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+#if (SICONOS_CXXVERSION >= 201103L)
 #define TO_STR(x) std::to_string(x)
 #else
 #include <boost/lexical_cast.hpp>

--- a/io/src/Register.hpp
+++ b/io/src/Register.hpp
@@ -28,7 +28,10 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/nvp.hpp>
 
-#if __cplusplus >= 201103L
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+#if SICONOS_CXXVERSION >= 201103L
 #include <boost/serialization/ser_shared_ptr.hpp>
 #else
 #include <boost/serialization/shared_ptr.hpp>

--- a/kernel/src/utils/SiconosAlgebra/SiconosAlgebraTypeDef.hpp
+++ b/kernel/src/utils/SiconosAlgebra/SiconosAlgebraTypeDef.hpp
@@ -43,7 +43,12 @@
 #include <limits>
 #include <boost/numeric/ublas/fwd.hpp>
 
-#if __cplusplus >= 201103L
+#include "SiconosConfig.h"
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+
+#if SICONOS_CXXVERSION >= 201103L
 #include <array>
 #else
 #include <boost/array.hpp>

--- a/kernel/src/utils/SiconosTools/Cmp.hpp
+++ b/kernel/src/utils/SiconosTools/Cmp.hpp
@@ -24,7 +24,10 @@ Classes related to object ordering in SiconosSet.
 #ifndef CMP_H
 #define CMP_H
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined
+#endif
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
 #include <memory>
 namespace std11 = std;
 #else

--- a/kernel/src/utils/SiconosTools/Question.hpp
+++ b/kernel/src/utils/SiconosTools/Question.hpp
@@ -44,7 +44,10 @@
 
 #include "SiconosVisitor.hpp"
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined
+#endif
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
 #include <type_traits>
 #include <array>
 #else

--- a/kernel/src/utils/SiconosTools/SiconosGraph.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosGraph.hpp
@@ -40,7 +40,12 @@
 #include <boost/config.hpp>
 #include <boost/version.hpp>
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#include <SiconosConfig.h>
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_MAP_FOR_HASH)
 #include <unordered_map>
 #else
 #include <map>
@@ -67,7 +72,7 @@ using std::size_t;
 #pragma clang diagnostic pop
 #endif
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
 namespace std11 = std;
 #else
 namespace std11 = boost;
@@ -189,7 +194,7 @@ public:
   //  typedef typename
   //  boost::property_map<graph_t, graph_properties_t >::type GraphPropertiesAccess;
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_MAP_FOR_HASH)
   typedef std::unordered_map<V, VDescriptor> VMap;
 #else
   typedef std::map<V, VDescriptor> VMap;
@@ -697,7 +702,7 @@ public:
 
       if (vdx == vd2) endl = true;
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_MAP_FOR_HASH)
       std::unordered_map<E, EDescriptor> Edone;
 #else
       std::map<E, EDescriptor> Edone;

--- a/kernel/src/utils/SiconosTools/SiconosPointers.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosPointers.hpp
@@ -62,7 +62,11 @@ More documentation on smart pointers and reference counting:
 
 #include <boost/shared_array.hpp>
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include "SiconosConfig.h"
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
 namespace std11 = std;
 #include <memory>
 #else

--- a/kernel/src/utils/SiconosTools/SiconosProperties.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosProperties.hpp
@@ -42,7 +42,13 @@
 #include <boost/property_map.hpp>
 #endif
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+
+#include <SiconosConfig.h>
+#ifndef SICONOS_CXXVERSION
+#error SICONOS_CXXVERSION is not defined in SiconosConfig.h
+#endif
+
+#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
 #include <memory>
 namespace std11 = std;
 #else

--- a/mechanics/src/contactDetection/bullet/BulletDS.cpp
+++ b/mechanics/src/contactDetection/bullet/BulletDS.cpp
@@ -130,7 +130,7 @@ void BulletDS::addCollisionObject(SP::btCollisionObject cobj,
                                   SP::SiconosVector ori,
                                   int group)
 {
-  boost::array<double, 7> xpos = { (*pos)(0), (*pos)(1), (*pos)(2),
+  std11::array<double, 7> xpos = { (*pos)(0), (*pos)(1), (*pos)(2),
                                    (*ori)(0), (*ori)(1), (*ori)(2), (*ori)(3)};
 
   (*_collisionObjects)[&*cobj] =  boost::tuple<SP::btCollisionObject,

--- a/mechanics/src/contactDetection/bullet/BulletDS_impl.hpp
+++ b/mechanics/src/contactDetection/bullet/BulletDS_impl.hpp
@@ -6,7 +6,7 @@
 #include <boost/tuple/tuple.hpp>
 
 #include "BulletDS.hpp"
-typedef boost::array<double, 7> OffSet;
+typedef std11::array<double, 7> OffSet;
 
 class CollisionObjects :
   public std::map<const btCollisionObject*,

--- a/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
+++ b/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
@@ -600,21 +600,21 @@ void  MBTB_initSimu(double hTS, int withProj)
   if(withProj==0)
   {
     sSimu.reset(new MBTB_TimeStepping(t,pOSI0,osnspb));
-    SP::MBTB_TimeStepping spSimu = (boost::static_pointer_cast<MBTB_TimeStepping>(sSimu));
+    SP::MBTB_TimeStepping spSimu = (std11::static_pointer_cast<MBTB_TimeStepping>(sSimu));
   }
   else if (withProj==1)
   {
     sSimu.reset(new MBTB_TimeSteppingProj(t,pOSI1,osnspb,osnspb_pos,sDParams[11]));
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(sDParams[9]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(sDParams[9]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
   }
   else if (withProj==2)
   {
     sSimu.reset(new MBTB_TimeSteppingCombinedProj(t,pOSI2,osnspb,osnspb_pos,2));
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTol(sDParams[9]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTol(sDParams[9]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
   }
 
   // --  OneStepIntegrators --
@@ -698,24 +698,24 @@ SP::Model MBTB_model()
 
 void MBTB_doProj(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoProj(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoProj(v);
 }
 void MBTB_doOnlyProj(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoOnlyProj(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoOnlyProj(v);
 }
 void MBTB_projectionMaxIteration(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(v);
 }
 void MBTB_constraintTol(double v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(v);
 }
 
 void MBTB_constraintTolUnilateral(double v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(v);
 }
 
 void MBTB_run(int NbSteps)

--- a/mechanics/src/mechanisms/MBTB/MBTB_internalTool.cpp
+++ b/mechanics/src/mechanisms/MBTB/MBTB_internalTool.cpp
@@ -231,11 +231,11 @@ void _MBTB_STEP()
   }
   else if (simuType == Type::TimeSteppingCombinedProjection)
   {
-    std::cout<< "     Number of projection iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbProjectionIteration() <<std::endl;
-    std::cout<< "     Number of cumulated Newton iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->cumulatedNewtonNbIterations() <<std::endl;
-    std::cout<< "     Number of set  iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbIndexSetsIteration() <<std::endl;
-    std::cout<< "     Max violation unilateral = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationUnilateral()  <<std::endl;
-    std::cout<< "     Max violation equality = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationEquality() <<std::endl;
+    std::cout<< "     Number of projection iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbProjectionIteration() <<std::endl;
+    std::cout<< "     Number of cumulated Newton iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->cumulatedNewtonNbIterations() <<std::endl;
+    std::cout<< "     Number of set  iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbIndexSetsIteration() <<std::endl;
+    std::cout<< "     Max violation unilateral = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationUnilateral()  <<std::endl;
+    std::cout<< "     Max violation equality = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationEquality() <<std::endl;
   }
   
   //sSimu->oneStepNSProblem(0)->display();


### PR DESCRIPTION
It seems that compiling software that uses C++11 against Siconos would successfully compile, but not link.  It turned out be because, by default, Siconos compiles without -std=c++11, and uses boost::shared_ptr, etc.  However, the use of boost::shared_ptr or std::shared_ptr is detected by the preprocessor by checking against __cplusplus in some headers.  So software including those headers when -std=c++11 was enabled would incorrectly choose the std:: namespace, when Siconos was compiled with the boost:: namespace.

This patch series:
  * Adds USE_CXX11 to CMake, which requests -std=c++11 enabled, and checks that it works during configuration.  An error is emitted if it is requested but not supported.  It is disabled by default.
  * Fixes some problematic areas in mechanics where boost::array or similar was used even when c++11 was enabled.
  * Replaces checks against __cplusplus in the headers with checks against SICONOS_CXXVERSION, which is hardcoded at configure time, guaranteeing that user software will select the shared_ptr type that Siconos was compiled with.