### PR TITLE
[cmake] Add detection of C++1x features, and store results in SiconosConfig.h

### DIFF
--- a/cmake/CXXCompilerSetup.cmake
+++ b/cmake/CXXCompilerSetup.cmake
@@ -10,10 +10,30 @@
 if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_CXX_COMPILER_WORKS)
   message(ABORT "no cxx compiler")
 endif()
-  
+
+# For SiconosConfig.h
+option(SICONOS_USE_BOOST_FOR_CXX11 "Prefer BOOST features over C++ standard features even if C++xy is enabled" ON)
+option(SICONOS_USE_MAP_FOR_HASH "Prefer std::map to std::unordered_map even if C++xy is enabled" ON)
+
 include(cxxTools)
 
+# Version of C++
 detect_cxx_standard(CXXVERSION)
+
+# Used to avoid tests below if same as previous run
+set("CXXVERSION_CUR" "${CXXVERSION}:${CMAKE_CXX_STANDARD}")
+
+# For SiconosConfig.h
+detect_cxx_std_shared_ptr(SICONOS_STD_SHARED_PTR)
+detect_cxx_std_array(SICONOS_STD_ARRAY)
+detect_cxx_std_unordered_map(SICONOS_STD_UNORDERED_MAP)
+detect_cxx_std_tuple(SICONOS_STD_TUPLE)
+detect_cxx_std_to_string(SICONOS_STD_TO_STRING)
+detect_cxx_std_functional(SICONOS_STD_FUNCTIONAL)
+
+# Used to avoid tests above if same as previous run
+set("CXXVERSION_LAST" "${CXXVERSION_CUR}"
+    CACHE INTERNAL "Last value of CXXVERSION" FORCE)
 
 # Check compiler version.
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/cmake/cxxTools.cmake
+++ b/cmake/cxxTools.cmake
@@ -46,7 +46,9 @@ endmacro(ADD_CXX_OPTIONS)
 # "There are many more known variants/revisions that we do not handle/detect."
 
 set(cxx_detect_code "
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201402L
+#error CXXVERSION 201402L
+#elif __cplusplus >= 201103L
 #error CXXVERSION 201103L
 #elif __cplusplus >= 199711L
 #error CXXVERSION 199711L
@@ -65,12 +67,18 @@ function(detect_cxx_standard output_var)
 
         enable_language(CXX)
 
+        if("${CMAKE_CXX_STANDARD}")
+          set(FLAGS_OPT "CMAKE_FLAGS")
+          set(FLAGS_VAL "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+        endif()
+
         try_run(
-            run_result_unused
-            compile_result_unused
-            "${CMAKE_BINARY_DIR}"
-            "${CMAKE_BINARY_DIR}/cxxversion.cpp"
-            COMPILE_OUTPUT_VARIABLE CXXVERSION
+          run_result_unused
+          compile_result_unused
+          "${CMAKE_BINARY_DIR}"
+          "${CMAKE_BINARY_DIR}/cxxversion.cpp"
+          COMPILE_OUTPUT_VARIABLE CXXVERSION
+          ${FLAGS_OPT} ${FLAGS_VAL}
         )
 
         # Parse the architecture name from the compiler output
@@ -103,3 +111,100 @@ function(detect_cxx_compiler_version gcc_compiler_version)
   endif()
 endfunction()
 
+function(detect_cxx_feature name codevar output_var)
+  file(WRITE "${CMAKE_BINARY_DIR}/CMakeFiles/${codevar}.cpp"
+             "${${codevar}_code}")
+
+  if(NOT "${CXXVERSION_CUR}" STREQUAL "${CXXVERSION_LAST}")
+
+    string(ASCII 27 UP)
+    set(UP "${UP}[1A")
+    message(STATUS "Checking to see if CXX compiler supports ${name}${UP}")
+
+    if("${CMAKE_CXX_STANDARD}")
+      set(FLAGS_OPT "CMAKE_FLAGS")
+      set(FLAGS_VAL "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+    endif()
+
+    try_run(
+      RUN_RESULT
+      COMPILE_RESULT
+      "${CMAKE_BINARY_DIR}"
+      "${CMAKE_BINARY_DIR}/CMakeFiles/${codevar}.cpp"
+      ${FLAGS_OPT} ${FLAGS_VAL}
+    )
+
+    if(COMPILE_RESULT AND (RUN_RESULT EQUAL 0))
+      set(RESULT yes)
+    else()
+      set(RESULT no)
+    endif()
+
+    message(STATUS "Checking to see if CXX compiler supports ${name} -- ${RESULT}")
+
+    set("${output_var}" "${RESULT}"
+      CACHE INTERNAL "Whether ${name} is supported" FORCE)
+
+  endif(NOT "${CXXVERSION_CUR}" STREQUAL "${CXXVERSION_LAST}")
+endfunction()
+
+# std::shared_ptr
+set(cxx_detect_std_shared_ptr_code "
+#include <memory>
+int main() { std::shared_ptr<int> i; return 0; }
+")
+
+function(detect_cxx_std_shared_ptr output_var)
+  detect_cxx_feature("std::shared_ptr" "cxx_detect_std_shared_ptr" "${output_var}")
+endfunction()
+
+# std::array
+set(cxx_detect_std_array_code "
+#include <array>
+int main() { std::array<int,1> i; return 0; }
+")
+
+function(detect_cxx_std_array output_var)
+  detect_cxx_feature("std::array" "cxx_detect_std_array" "${output_var}")
+endfunction()
+
+# std::unordered_map
+set(cxx_detect_std_unordered_map_code "
+#include <unordered_map>
+int main() { std::unordered_map<int,int> i; return 0; }
+")
+
+function(detect_cxx_std_unordered_map output_var)
+  detect_cxx_feature("std::unordered_map" "cxx_detect_std_unordered_map" "${output_var}")
+endfunction()
+
+# std::tuple / tie
+set(cxx_detect_std_tuple_code "
+#include <tuple>
+int main() { int i,j; std::tie(i,j) = std::make_tuple<int,int>(0,0); return 0; }
+")
+
+function(detect_cxx_std_tuple output_var)
+  detect_cxx_feature("std::tuple" "cxx_detect_std_tuple" "${output_var}")
+endfunction()
+
+# std::to_string
+set(cxx_detect_std_to_string_code "
+#include <string>
+int main() { std::string s(std::to_string(0L)); return 0; }
+")
+
+function(detect_cxx_std_to_string output_var)
+  detect_cxx_feature("std::to_string" "cxx_detect_std_to_string" "${output_var}")
+endfunction()
+
+# std::bind and functional
+set(cxx_detect_std_functional_code "
+#include <functional>
+int add(int x,int y) { return x+y; }
+int main() { return std::bind(add,1,std::placeholders::_1)(-1); }
+")
+
+function(detect_cxx_std_functional output_var)
+  detect_cxx_feature("std::bind" "cxx_detect_std_functional" "${output_var}")
+endfunction()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -65,6 +65,13 @@
 
 // Which version of C++ was used to compile siconos, needed for swig
 #define SICONOS_CXXVERSION @CXXVERSION@
-
+#cmakedefine SICONOS_USE_BOOST_FOR_CXX11
+#cmakedefine SICONOS_USE_MAP_FOR_HASH
+#cmakedefine SICONOS_STD_SHARED_PTR
+#cmakedefine SICONOS_STD_ARRAY
+#cmakedefine SICONOS_STD_UNORDERED_MAP
+#cmakedefine SICONOS_STD_TUPLE
+#cmakedefine SICONOS_STD_TO_STRING
+#cmakedefine SICONOS_STD_FUNCTIONAL
 
 #endif

--- a/control/src/Simulation/ControlSimulation_impl.hpp
+++ b/control/src/Simulation/ControlSimulation_impl.hpp
@@ -28,8 +28,8 @@
 
 #include "SimulationTypeDef.hpp"
 
-
-#if (__cplusplus >= 201103L)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_TO_STRING) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #define TO_STR(x) std::to_string(x)
 #else
 #include <boost/lexical_cast.hpp>

--- a/io/src/Register.hpp
+++ b/io/src/Register.hpp
@@ -28,7 +28,7 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/nvp.hpp>
 
-#if __cplusplus >= 201103L
+#if defined(SICONOS_STD_SHARED_PTR) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <boost/serialization/ser_shared_ptr.hpp>
 #else
 #include <boost/serialization/shared_ptr.hpp>

--- a/kernel/src/simulationTools/OneStepIntegrator.cpp
+++ b/kernel/src/simulationTools/OneStepIntegrator.cpp
@@ -24,7 +24,8 @@
 #include "NonSmoothDynamicalSystem.hpp"
 #include "ExtraAdditionalTerms.hpp"
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_FUNCTIONAL) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <functional>
 using namespace std::placeholders;
 #else

--- a/kernel/src/simulationTools/TimeStepping.cpp
+++ b/kernel/src/simulationTools/TimeStepping.cpp
@@ -38,7 +38,8 @@
 #include "NewtonEulerR.hpp"
 #include "FirstOrderR.hpp"
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_FUNCTIONAL) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <functional>
 using namespace std::placeholders;
 #else

--- a/kernel/src/simulationTools/TimeSteppingD1Minus.cpp
+++ b/kernel/src/simulationTools/TimeSteppingD1Minus.cpp
@@ -38,7 +38,8 @@
 
 #include <ciso646>
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_FUNCTIONAL) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <functional>
 using namespace std::placeholders;
 #else

--- a/kernel/src/utils/SiconosAlgebra/SiconosAlgebraTypeDef.hpp
+++ b/kernel/src/utils/SiconosAlgebra/SiconosAlgebraTypeDef.hpp
@@ -43,7 +43,8 @@
 #include <limits>
 #include <boost/numeric/ublas/fwd.hpp>
 
-#if __cplusplus >= 201103L
+#include "SiconosConfig.h"
+#if defined(SICONOS_STD_ARRAY) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <array>
 #else
 #include <boost/array.hpp>

--- a/kernel/src/utils/SiconosTools/Cmp.hpp
+++ b/kernel/src/utils/SiconosTools/Cmp.hpp
@@ -24,7 +24,8 @@ Classes related to object ordering in SiconosSet.
 #ifndef CMP_H
 #define CMP_H
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_SHARED_PTR) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <memory>
 namespace std11 = std;
 #else

--- a/kernel/src/utils/SiconosTools/Question.hpp
+++ b/kernel/src/utils/SiconosTools/Question.hpp
@@ -44,7 +44,8 @@
 
 #include "SiconosVisitor.hpp"
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_ARRAY) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <type_traits>
 #include <array>
 #else

--- a/kernel/src/utils/SiconosTools/SiconosGraph.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosGraph.hpp
@@ -40,7 +40,8 @@
 #include <boost/config.hpp>
 #include <boost/version.hpp>
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_UNORDERED_MAP) && !defined(SICONOS_USE_MAP_FOR_HASH)
 #include <unordered_map>
 #else
 #include <map>
@@ -67,7 +68,7 @@ using std::size_t;
 #pragma clang diagnostic pop
 #endif
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#if defined(SICONOS_STD_TUPLE) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 namespace std11 = std;
 #else
 namespace std11 = boost;
@@ -189,7 +190,7 @@ public:
   //  typedef typename
   //  boost::property_map<graph_t, graph_properties_t >::type GraphPropertiesAccess;
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#if defined(SICONOS_STD_UNORDERED_MAP) && !defined(SICONOS_USE_MAP_FOR_HASH)
   typedef std::unordered_map<V, VDescriptor> VMap;
 #else
   typedef std::map<V, VDescriptor> VMap;
@@ -697,7 +698,7 @@ public:
 
       if (vdx == vd2) endl = true;
 
-#if (__cplusplus >= 201103L) && !defined(USE_MAP_FOR_HASH)
+#if defined(SICONOS_STD_UNORDERED_MAP) && !defined(SICONOS_USE_MAP_FOR_HASH)
       std::unordered_map<E, EDescriptor> Edone;
 #else
       std::map<E, EDescriptor> Edone;

--- a/kernel/src/utils/SiconosTools/SiconosPointers.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosPointers.hpp
@@ -62,7 +62,8 @@ More documentation on smart pointers and reference counting:
 
 #include <boost/shared_array.hpp>
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_SHARED_PTR) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 namespace std11 = std;
 #include <memory>
 #else

--- a/kernel/src/utils/SiconosTools/SiconosProperties.hpp
+++ b/kernel/src/utils/SiconosTools/SiconosProperties.hpp
@@ -42,7 +42,9 @@
 #include <boost/property_map.hpp>
 #endif
 
-#if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+
+#include <SiconosConfig.h>
+#if defined(SICONOS_STD_SHARED_PTR) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #include <memory>
 namespace std11 = std;
 #else

--- a/mechanics/src/contactDetection/bullet/BulletDS.cpp
+++ b/mechanics/src/contactDetection/bullet/BulletDS.cpp
@@ -130,7 +130,7 @@ void BulletDS::addCollisionObject(SP::btCollisionObject cobj,
                                   SP::SiconosVector ori,
                                   int group)
 {
-  boost::array<double, 7> xpos = { (*pos)(0), (*pos)(1), (*pos)(2),
+  std11::array<double, 7> xpos = { (*pos)(0), (*pos)(1), (*pos)(2),
                                    (*ori)(0), (*ori)(1), (*ori)(2), (*ori)(3)};
 
   (*_collisionObjects)[&*cobj] =  boost::tuple<SP::btCollisionObject,

--- a/mechanics/src/contactDetection/bullet/BulletDS_impl.hpp
+++ b/mechanics/src/contactDetection/bullet/BulletDS_impl.hpp
@@ -6,7 +6,7 @@
 #include <boost/tuple/tuple.hpp>
 
 #include "BulletDS.hpp"
-typedef boost::array<double, 7> OffSet;
+typedef std11::array<double, 7> OffSet;
 
 class CollisionObjects :
   public std::map<const btCollisionObject*,

--- a/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
+++ b/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
@@ -600,21 +600,21 @@ void  MBTB_initSimu(double hTS, int withProj)
   if(withProj==0)
   {
     sSimu.reset(new MBTB_TimeStepping(t,pOSI0,osnspb));
-    SP::MBTB_TimeStepping spSimu = (boost::static_pointer_cast<MBTB_TimeStepping>(sSimu));
+    SP::MBTB_TimeStepping spSimu = (std11::static_pointer_cast<MBTB_TimeStepping>(sSimu));
   }
   else if (withProj==1)
   {
     sSimu.reset(new MBTB_TimeSteppingProj(t,pOSI1,osnspb,osnspb_pos,sDParams[11]));
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(sDParams[9]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(sDParams[9]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
   }
   else if (withProj==2)
   {
     sSimu.reset(new MBTB_TimeSteppingCombinedProj(t,pOSI2,osnspb,osnspb_pos,2));
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTol(sDParams[9]);
-    (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setProjectionMaxIteration(sDParams[8]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTol(sDParams[9]);
+    (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->setConstraintTolUnilateral(sDParams[10]);
   }
 
   // --  OneStepIntegrators --
@@ -698,24 +698,24 @@ SP::Model MBTB_model()
 
 void MBTB_doProj(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoProj(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoProj(v);
 }
 void MBTB_doOnlyProj(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoOnlyProj(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setDoOnlyProj(v);
 }
 void MBTB_projectionMaxIteration(unsigned int v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setProjectionMaxIteration(v);
 }
 void MBTB_constraintTol(double v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTol(v);
 }
 
 void MBTB_constraintTolUnilateral(double v)
 {
-  (boost::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(v);
+  (std11::static_pointer_cast<MBTB_TimeSteppingProj>(sSimu))->setConstraintTolUnilateral(v);
 }
 
 void MBTB_run(int NbSteps)

--- a/mechanics/src/mechanisms/MBTB/MBTB_internalTool.cpp
+++ b/mechanics/src/mechanisms/MBTB/MBTB_internalTool.cpp
@@ -231,11 +231,11 @@ void _MBTB_STEP()
   }
   else if (simuType == Type::TimeSteppingCombinedProjection)
   {
-    std::cout<< "     Number of projection iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbProjectionIteration() <<std::endl;
-    std::cout<< "     Number of cumulated Newton iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->cumulatedNewtonNbIterations() <<std::endl;
-    std::cout<< "     Number of set  iterations = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbIndexSetsIteration() <<std::endl;
-    std::cout<< "     Max violation unilateral = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationUnilateral()  <<std::endl;
-    std::cout<< "     Max violation equality = " <<  (boost::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationEquality() <<std::endl;
+    std::cout<< "     Number of projection iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbProjectionIteration() <<std::endl;
+    std::cout<< "     Number of cumulated Newton iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->cumulatedNewtonNbIterations() <<std::endl;
+    std::cout<< "     Number of set  iterations = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->nbIndexSetsIteration() <<std::endl;
+    std::cout<< "     Max violation unilateral = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationUnilateral()  <<std::endl;
+    std::cout<< "     Max violation equality = " <<  (std11::static_pointer_cast<MBTB_TimeSteppingCombinedProj>(sSimu))->maxViolationEquality() <<std::endl;
   }
   
   //sSimu->oneStepNSProblem(0)->display();

--- a/numerics/src/tools/debug.h
+++ b/numerics/src/tools/debug.h
@@ -73,7 +73,7 @@
 DEBUG_PRINT(#NAME " matrix\n"); \
 DEBUG_EXPR_WE(for (unsigned i = 0; i < nrows; ++i) \
   { for(unsigned j = 0 ; j < ncols; ++j) \
-  { DEBUG_PRINTF(ANSI_COLOR_BLUE" % 2.2e "ANSI_COLOR_RESET, M[i + j*nrows]) } \
+  { DEBUG_PRINTF(ANSI_COLOR_BLUE " % 2.2e " ANSI_COLOR_RESET, M[i + j*nrows]) } \
    DEBUG_PRINT("\n")});
 
 #define DEBUG_PRINT_MAT(M, nrows, ncols) DEBUG_PRINT_MAT_STR(#M, M, nrows, ncols)
@@ -118,7 +118,7 @@ DEBUG_EXPR_WE(for (unsigned i = 0; i < nrows; ++i) \
 #define DEBUG_PRINT_MAT_ROW_MAJOR_NCOLS_SMALL2_STR(NAME, M, nrows, ncols, ncols_to_display, ...) \
 DEBUG_PRINT(#NAME " matrix\n"); \
 DEBUG_EXPR_WE( double* _arr_[] = {__VA_ARGS__}; for (unsigned i = 0; i < nrows; ++i) \
-  { for (unsigned k = 0; k < sizeof(_arr_)/sizeof(double*); ++k) {DEBUG_PRINTF(ANSI_COLOR_YELLOW "% 1.0e "ANSI_COLOR_RESET, _arr_[k][i])} \
+  { for (unsigned k = 0; k < sizeof(_arr_)/sizeof(double*); ++k) {DEBUG_PRINTF(ANSI_COLOR_YELLOW "% 1.0e " ANSI_COLOR_RESET, _arr_[k][i])} \
     for(unsigned j = 0 ; j < ncols_to_display; ++j) \
   { if (fabs(M[i*ncols + j]) > 2.2e-16) {DEBUG_PRINTF(ANSI_COLOR_YELLOW "% 1.0e " ANSI_COLOR_RESET, M[i*ncols + j])} \
     else { DEBUG_PRINT(ANSI_COLOR_BLUE " 0 " ANSI_COLOR_RESET) } } \

--- a/wrap/swig/sharedPointers.i
+++ b/wrap/swig/sharedPointers.i
@@ -7,7 +7,7 @@
 
 %import SiconosConfig.h
 
-#if (SICONOS_CXXVERSION >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
+#if defined(SICONOS_STD_SHARED_PTR) && !defined(SICONOS_USE_BOOST_FOR_CXX11)
 #define STD11 std
 #undef __cplusplus
 #define __cplusplus SICONOS_CXXVERSION


### PR DESCRIPTION
This PR includes the changes from PR #9, but proposes a different approach for handling C++1x features.  To summarize:

> The use of boost::shared_ptr or std::shared_ptr is detected by the preprocessor by checking against __cplusplus in some headers. So software including those headers when -std=c++11 was enabled would incorrectly choose the std:: namespace, when Siconos was compiled with the boost:: namespace.  This caused linker errors.

This patch:

  * Adds detection of individual C++11 features, such as std::shared_ptr, std::array, std::unordered_map, std::to_string, std::bind.
  * Detection variables are stored in SiconosConfig.h
    - e.g., SICONOS_STD_SHARED_PTR, etc..
  * User flags to turn *off* use of these features are also stored in SiconosConfig.h:
    - SICONOS_USE_BOOST_FOR_CXX11
    - SICONOS_USE_MAP_FOR_HASH
  * Fixes some problematic areas in mechanics where boost::array or similar was used even when c++11 was enabled.
  * Replaces checks against __cplusplus in the headers with checks against specific feature variables.

Note that CMake's own mechanism for setting the C++ standard must be used to select C++11 or C++14:

    cmake .. -DCMAKE_CXX_STANDARD=11

This option is explicitly passed on to the detection try_run() calls.