### PR TITLE
Fix build error with non MSVC compiler on Windows platform

### DIFF
--- a/cmake/PythonWindowsSetup.cmake
+++ b/cmake/PythonWindowsSetup.cmake
@@ -8,7 +8,7 @@ if(WITH_TESTING)
   ENDIF()
 endif()
 
-IF(CMAKE_SYSTEM_NAME MATCHES Windows)
+IF(MSVC)
   SET(VAR_SEPARATOR ";")
   APPEND_CXX_FLAGS("/bigobj")
 ELSE()

--- a/cmake/swig_python_tools.cmake
+++ b/cmake/swig_python_tools.cmake
@@ -110,7 +110,7 @@ macro(add_siconos_swig_sub_module fullname)
   set_property(TARGET ${SWIG_MODULE_${_name}_REAL_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${SICONOS_SWIG_ROOT_DIR}/${_path})
   message(" -- ${_name} generated (swig) file will be ${${_name}_generated_file_fullname}")
   
-  IF(CMAKE_SYSTEM_NAME MATCHES Windows AND ${COMPONENT} MATCHES "kernel")
+  IF(MSVC AND ${COMPONENT} MATCHES "kernel")
     set_source_files_properties(${${_name}_generated_file_fullname} PROPERTIES COMPILE_FLAGS "/bigobj")
   ENDIF()
  


### PR DESCRIPTION
I've tried to build siconos on Windows inside MSYS2. MSYS2 uses MinGW as compiler and I've encountered errors about the `/bigobj` command option.

This option is only for the MSVC compiler, hence the fix that replaces `CMAKE_SYSTEM_NAME MATCHES Windows` by `MSVC` variable in cmake files.

I can't test the fix with the Visual Studio Compiler, but it works within the MSYS2 platform using MinGW-32 and MinGW-64.

Thanks,
François

 