### PR TITLE
[kernel] split update() into 3 steps, call updateOutput() only if Newton not done

### DIFF
--- a/kernel/src/simulationTools/EventDriven.cpp
+++ b/kernel/src/simulationTools/EventDriven.cpp
@@ -582,8 +582,7 @@ void EventDriven::updateSmoothState()
     (*itOSI)->updateState(2);
 }
 
-
-void EventDriven::update(unsigned int levelInput)
+void EventDriven::updateState(unsigned int levelInput)
 {
   assert(levelInput <= 2);
   if (levelInput == 1)
@@ -594,6 +593,10 @@ void EventDriven::update(unsigned int levelInput)
   {
     updateSmoothState();
   }
+}
+
+void EventDriven::updateOutput(unsigned int levelInput)
+{
   // Update output (y)
   _nsds->updateOutput(nextTime(),levelInput);
   // Warning: index sets are not updated in this function !!
@@ -627,9 +630,9 @@ void EventDriven::advanceToEvent()
     // Update input of level 2 >>> has already been done in newtonSolve
     // Update state of all Dynamicall Systems >>>  has already been done in newtonSolve
     // Update outputs of levels 0, 1, 2
-    _nsds->updateOutput(nextTime(),0);
-    _nsds->updateOutput(nextTime(),1);
-    _nsds->updateOutput(nextTime(),2);
+    updateOutput(0);
+    updateOutput(1);
+    updateOutput(2);
     // Detect whether or not some events occur during the integration step
     _minConstraint = detectEvents();
     //
@@ -720,9 +723,9 @@ void EventDriven::advanceToEvent()
     }
     // Set model time to _tout
     //update output[0], output[1], output[2]
-    _nsds->updateOutput(nextTime(),0);
-    _nsds->updateOutput(nextTime(),1);
-    _nsds->updateOutput(nextTime(),2);
+    updateOutput(0);
+    updateOutput(1);
+    updateOutput(2);
     //update lambda[2], input[2] and indexSet[2] with double consitions for the case there is no new event added during time integration, otherwise, this
     // update is done when the new event is processed
     if (!isNewEventOccur)

--- a/kernel/src/simulationTools/EventDriven.hpp
+++ b/kernel/src/simulationTools/EventDriven.hpp
@@ -288,10 +288,20 @@ public:
 
   void updateSmoothState();
 
-  /** update input, output and indexSets.
+  /** update input
    *  \param level of lambda  used to compute input
    */
-  void update(unsigned int level);
+  void updateInput(unsigned int level) {}
+
+  /** update state.
+   *  \param level of lambda  used to compute input
+   */
+  void updateState(unsigned int level);
+
+  /** update output and indexSets.
+   *  \param level of lambda  used to compute input
+   */
+  void updateOutput(unsigned int level);
 
   /** Initialize EventDriven **/
 

--- a/kernel/src/simulationTools/Simulation.cpp
+++ b/kernel/src/simulationTools/Simulation.cpp
@@ -475,3 +475,42 @@ void Simulation::updateInteractions()
       initOSNS();
   }
 }
+
+void Simulation::updateInput(unsigned int)
+{
+  DEBUG_BEGIN("Simulation::updateInput()\n");
+  OSIIterator itOSI;
+  // 1 - compute input (lambda -> r)
+  if (!_allNSProblems->empty())
+  {
+    for (itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
+      (*itOSI)->updateInput(nextTime());
+    //_nsds->updateInput(nextTime(),levelInput);
+  }
+  DEBUG_END("Simulation::updateInput()\n");
+}
+
+void Simulation::updateState(unsigned int)
+{
+  DEBUG_BEGIN("Simulation::updateState()\n");
+  OSIIterator itOSI;
+  // 2 - compute state for each dynamical system
+  for (itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
+    (*itOSI)->updateState();
+
+  DEBUG_END("Simulation::updateState()\n");
+}
+
+void Simulation::updateOutput(unsigned int)
+{
+  DEBUG_BEGIN("Simulation::updateOutput()\n");
+
+  // 3 - compute output ( x ... -> y)
+  if (!_allNSProblems->empty())
+  {
+    OSIIterator itOSI;
+    for (itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
+      (*itOSI)->updateOutput(nextTime());
+  }
+  DEBUG_END("Simulation::updateOutput()\n");
+}

--- a/kernel/src/simulationTools/Simulation.hpp
+++ b/kernel/src/simulationTools/Simulation.hpp
@@ -146,6 +146,13 @@ protected:
   /** Call the interaction manager one if is registered, otherwise do nothing. */
   void updateInteractions();
 
+  /*TS set the ds->q memory, the world (CAD model for example) must be updated.
+    Overload this method to update user model.*/
+  virtual void updateWorldFromDS()
+  {
+    ;
+  };
+
 private:
 
   /** copy constructor. Private => no copy nor pass-by value.
@@ -404,10 +411,28 @@ public:
    */
   int computeOneStepNSProblem(int nb);
 
-  /** update input, state of each dynamical system and output
+  /** update input
    *  \param level lambda order used to compute input
+   * level is set to 0 by default since in all time-stepping schemes we update all the state
    */
-  virtual void update(unsigned int level) = 0;
+  virtual void updateInput(unsigned int level=0);
+
+  /** update state of each dynamical system
+   */
+  virtual void updateState(unsigned int level=0);
+
+  /** update output
+   *  \param level lambda order used to compute output
+   * level is set to 0 by default since in all time-stepping schemes we update all the state
+   */
+  virtual void updateOutput(unsigned int level=0);
+
+  /** update output, state, and input
+   *  \param level lambda order used to compute input
+   * level is set to 0 by default since in all time-stepping schemes we update all the state
+   */
+  void update(unsigned int level=0)
+    { updateInput(level); updateState(level); updateOutput(level); }
 
   /** run the simulation, from t0 to T
    * with default parameters if any particular settings has been done

--- a/kernel/src/simulationTools/TimeStepping.hpp
+++ b/kernel/src/simulationTools/TimeStepping.hpp
@@ -159,12 +159,6 @@ public:
   /** increment model current time according to User TimeDiscretisation and call SaveInMemory. */
   virtual void nextStep();
 
-  /** update input, state of each dynamical system and output
-   *  \param level lambda order used to compute input
-   * level is set to 0 by default since in all time-stepping schemes we update all the state
-   */
-  virtual void update(unsigned int level=0);
-
   /** integrates all the DynamicalSystems taking not into account nslaw, reactions (ie non-smooth part) ...
   */
   void computeFreeState();
@@ -360,16 +354,6 @@ public:
   {
     return _newtonResiduRMax;
   };
-
-
-  /*TS set the ds->q memory, the world (CAD model for example) must be updated.
-    Overload this method to update user model.*/
-  virtual void updateWorldFromDS()
-  {
-    ;
-  };
-
-
 
   /** visitors hook
   */

--- a/kernel/src/simulationTools/TimeSteppingD1Minus.cpp
+++ b/kernel/src/simulationTools/TimeSteppingD1Minus.cpp
@@ -64,10 +64,8 @@ void TimeSteppingD1Minus::initOSNS()
     //update all index sets
     updateIndexSets();
 
-
     // update output
-    for (OSIIterator itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
-      (*itOSI)->updateOutput(nextTime());
+    updateOutput();
   }
 }
 
@@ -163,29 +161,6 @@ void TimeSteppingD1Minus::updateIndexSet(unsigned int i)
   DEBUG_PRINTF("\nINDEXSETS AFTER UPDATE for level i = %i\n", i);
   DEBUG_PRINTF(" indexSet0 size : %ld\n", indexSet0->size());
   DEBUG_PRINTF(" indexSet(%i) size : %ld\n", i, topo->indexSet(i)->size());
-}
-
-void TimeSteppingD1Minus::update(unsigned int level)
-{
-  // compute input (lambda -> r)
-  if (!_allNSProblems->empty())
-  {
-    for (OSIIterator itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
-      (*itOSI)->updateInput(nextTime(),level);
-    //_nsds->updateInput(nextTime(),levelInput);
-  }
-
-  // compute state for each dynamical system
-  for (OSIIterator itOSI = _allOSI->begin(); itOSI != _allOSI->end(); ++itOSI)
-    (*itOSI)->updateState();
-
-
-  // 3 - compute output ( x ... -> y)
-  if (!_allNSProblems->empty())
-  {
-    for (OSIIterator itOSI = _allOSI->begin(); itOSI != _allOSI->end() ; ++itOSI)
-      (*itOSI)->updateOutput(nextTime(),level);
-  }
 }
 
 void TimeSteppingD1Minus::run()

--- a/kernel/src/simulationTools/TimeSteppingD1Minus.hpp
+++ b/kernel/src/simulationTools/TimeSteppingD1Minus.hpp
@@ -66,11 +66,6 @@ public:
    */
   virtual void updateIndexSet(unsigned int i);
 
-  /** update input, state and output of DynamicalSystems
-   *  \param levelInput to be updated for input
-   */
-  virtual void update(unsigned int levelInput);
-
   /** run the simulation, from t0 to T */
   virtual void run();
 

--- a/kernel/src/simulationTools/TimeSteppingDirectProjection.cpp
+++ b/kernel/src/simulationTools/TimeSteppingDirectProjection.cpp
@@ -613,10 +613,12 @@ void TimeSteppingDirectProjection::newtonSolve(double criterion, unsigned int ma
       else
         checkSolverOutputProjectOnConstraints(info, this);
 
-      update();
+      updateInput();
+      updateState();
       isNewtonConverge = newtonCheckConvergence(criterion);
       if (!isNewtonConverge && !info)
       {
+        updateOutput();
         if (!_allNSProblems->empty() &&  indexSet->size()>0)
           saveYandLambdaInOldVariables();
       }


### PR DESCRIPTION
I noticed that the function update() combines the 3 steps, updateInput(), updateState(), and updateOutput().  Typically one needs to update Interaction data based on DS positions before updateOutput() sets up `y` for the solver.  This includes calling the contact detection engine.

However, there is no reason to call the engine again (or updateOutput()?) if the loop is finished, right?

Any reason not to split it up and put updateInteractions() and updateOutput() in the conditional?

I leave a default implementation of update() which calls the 3 functions consecutively.
