### PR TITLE
[kernel] Move all DS insertion and initialization to NSDS::insertDyna…

### DIFF
--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -161,7 +161,7 @@ void CommonSMC::initialize(const Model& m)
   _SMC->nonSmoothDynamicalSystem()->setControlProperty(_interactionSMC, true);
   _SMC->nonSmoothDynamicalSystem()->topology()->setName(_interactionSMC, "Sgn_SMC");
   _simulationSMC->setName("linear sliding mode controller simulation");
-  _simulationSMC->insertIntegrator(_integratorSMC);
+  _simulationSMC->initializeOSIforDS(_integratorSMC, _DS_SMC, _SMC, t0);
   // OneStepNsProblem
   _OSNSPB_SMC->numericsSolverOptions()->dparam[0] = _precision;
   //    std::cout << _OSNSPB_SMC->numericsSolverOptions()->dparam[0] <<std::endl;

--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -155,8 +155,8 @@ void CommonSMC::initialize(const Model& m)
     _integratorSMC.reset(new ZeroOrderHoldOSI());
   }
 
-  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC);
-  _SMC->nonSmoothDynamicalSystem()->topology()->setOSI(_DS_SMC, _integratorSMC);
+  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC, _SMC,
+                                                          t0, _integratorSMC);
   _SMC->nonSmoothDynamicalSystem()->setName(_DS_SMC, "plant_SMC");
   _SMC->nonSmoothDynamicalSystem()->link(_interactionSMC, _DS_SMC);
   _SMC->nonSmoothDynamicalSystem()->setControlProperty(_interactionSMC, true);

--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -155,8 +155,7 @@ void CommonSMC::initialize(const Model& m)
     _integratorSMC.reset(new ZeroOrderHoldOSI());
   }
 
-  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC, _SMC,
-                                                          t0, _integratorSMC);
+  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC);
   _SMC->nonSmoothDynamicalSystem()->setName(_DS_SMC, "plant_SMC");
   _SMC->nonSmoothDynamicalSystem()->link(_interactionSMC, _DS_SMC);
   _SMC->nonSmoothDynamicalSystem()->setControlProperty(_interactionSMC, true);

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -113,7 +113,7 @@ void LinearSMCOT2::initialize(const Model& m)
   _PhiOSI.reset(new LsodarOSI());
   _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi);
   _simulPhi.reset(new EventDriven(_tdPhi, 0));
-  _simulPhi->insertIntegrator(_PhiOSI);
+  _simulPhi->initializeOSIforDS(_PhiOSI, _DSPhi, _modelPhi, _t0);
   _modelPhi->setSimulation(_simulPhi);
   _modelPhi->initialize();
   // Integration for Gamma
@@ -121,7 +121,7 @@ void LinearSMCOT2::initialize(const Model& m)
   _PredOSI.reset(new LsodarOSI());
   _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred);
   _simulPred.reset(new EventDriven(_tdPred, 0));
-  _simulPred->insertIntegrator(_PredOSI);
+  _simulPred->initializeOSIforDS(_PredOSI, _DSPred, _modelPred, _t0);
   _modelPred->setSimulation(_simulPred);
   _modelPred->initialize();
 

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -111,8 +111,7 @@ void LinearSMCOT2::initialize(const Model& m)
 
   _modelPhi.reset(new Model(_t0, _T));
   _PhiOSI.reset(new LsodarOSI());
-  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi, _modelPhi,
-                                                               _t0, _PhiOSI);
+  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi);
   _simulPhi.reset(new EventDriven(_tdPhi, 0));
   _simulPhi->insertIntegrator(_PhiOSI);
   _modelPhi->setSimulation(_simulPhi);
@@ -120,8 +119,7 @@ void LinearSMCOT2::initialize(const Model& m)
   // Integration for Gamma
   _modelPred.reset(new Model(_t0, _T));
   _PredOSI.reset(new LsodarOSI());
-  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred, _modelPred,
-                                                                _t0, _PredOSI);
+  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred);
   _simulPred.reset(new EventDriven(_tdPred, 0));
   _simulPred->insertIntegrator(_PredOSI);
   _modelPred->setSimulation(_simulPred);

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -111,8 +111,8 @@ void LinearSMCOT2::initialize(const Model& m)
 
   _modelPhi.reset(new Model(_t0, _T));
   _PhiOSI.reset(new LsodarOSI());
-  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi);
-  _modelPhi->nonSmoothDynamicalSystem()->topology()->setOSI(_DSPhi, _PhiOSI);
+  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi, _modelPhi,
+                                                               _t0, _PhiOSI);
   _simulPhi.reset(new EventDriven(_tdPhi, 0));
   _simulPhi->insertIntegrator(_PhiOSI);
   _modelPhi->setSimulation(_simulPhi);
@@ -120,8 +120,8 @@ void LinearSMCOT2::initialize(const Model& m)
   // Integration for Gamma
   _modelPred.reset(new Model(_t0, _T));
   _PredOSI.reset(new LsodarOSI());
-  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred);
-  _modelPred->nonSmoothDynamicalSystem()->topology()->setOSI(_DSPred, _PredOSI);
+  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred, _modelPred,
+                                                                _t0, _PredOSI);
   _simulPred.reset(new EventDriven(_tdPred, 0));
   _simulPred->insertIntegrator(_PredOSI);
   _modelPred->setSimulation(_simulPred);

--- a/control/src/Observer/LuenbergerObserver.cpp
+++ b/control/src/Observer/LuenbergerObserver.cpp
@@ -87,8 +87,7 @@ void LuenbergerObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model,
-                                                            t0, _integrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);

--- a/control/src/Observer/LuenbergerObserver.cpp
+++ b/control/src/Observer/LuenbergerObserver.cpp
@@ -87,8 +87,8 @@ void LuenbergerObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _integrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model,
+                                                            t0, _integrator);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);

--- a/control/src/Observer/LuenbergerObserver.cpp
+++ b/control/src/Observer/LuenbergerObserver.cpp
@@ -106,7 +106,7 @@ void LuenbergerObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->insertIntegrator(_integrator);
+  _simulation->initializeOSIforDS(_integrator, _DS, _model, t0);
   _model->setSimulation(_simulation);
   _model->initialize();
 

--- a/control/src/Observer/SlidingReducedOrderObserver.cpp
+++ b/control/src/Observer/SlidingReducedOrderObserver.cpp
@@ -87,8 +87,8 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _integrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model,
+                                                            t0, _integrator);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);

--- a/control/src/Observer/SlidingReducedOrderObserver.cpp
+++ b/control/src/Observer/SlidingReducedOrderObserver.cpp
@@ -106,10 +106,10 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->insertIntegrator(_integrator);
+  _simulation->initializeOSIforDS(_integrator, _DS, _model, t0);
   _model->setSimulation(_simulation);
   _model->initialize();
- 
+
   // initialize error
   *_y = _sensor->y();
 }

--- a/control/src/Observer/SlidingReducedOrderObserver.cpp
+++ b/control/src/Observer/SlidingReducedOrderObserver.cpp
@@ -87,8 +87,7 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model,
-                                                            t0, _integrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);

--- a/control/src/Simulation/ControlSimulation.cpp
+++ b/control/src/Simulation/ControlSimulation.cpp
@@ -93,8 +93,10 @@ void ControlSimulation::setTheta(unsigned int newTheta)
 
 void ControlSimulation::addDynamicalSystem(SP::DynamicalSystem ds, const std::string& name)
 {
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(
-    ds, _model, _processSimulation->nextTime(), _processIntegrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
+
+  _processSimulation->initializeOSIforDS(_processIntegrator, ds, _model,
+                                         _processSimulation->nextTime());
 
   if (!name.empty())
   {

--- a/control/src/Simulation/ControlSimulation.cpp
+++ b/control/src/Simulation/ControlSimulation.cpp
@@ -93,8 +93,8 @@ void ControlSimulation::setTheta(unsigned int newTheta)
 
 void ControlSimulation::addDynamicalSystem(SP::DynamicalSystem ds, const std::string& name)
 {
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(ds, _processIntegrator);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(
+    ds, _model, _processSimulation->nextTime(), _processIntegrator);
 
   if (!name.empty())
   {

--- a/control/swig/tests/test_smc.py
+++ b/control/swig/tests/test_smc.py
@@ -60,8 +60,7 @@ def test_smc1():
     processSimulation.setName("plant simulation")
     # Declaration of the integrator
     processIntegrator = ZeroOrderHoldOSI()
-    process.nonSmoothDynamicalSystem().topology().setOSI(processDS, processIntegrator)
-    processSimulation.insertIntegrator(processIntegrator)
+    processSimulation.initializeOSIforDS(processIntegrator, processDS, process, t0)
     # Actuator, Sensor & ControlManager
     control = ControlManager(processSimulation)
     sens = LinearSensor(processDS, sensorC, sensorD)

--- a/examples/Control/Relay/RelayBiSimulation.cpp
+++ b/examples/Control/Relay/RelayBiSimulation.cpp
@@ -122,8 +122,7 @@ int main(int argc, char* argv[])
     // -- OneStepIntegrators --
     double theta = 0.5;
     SP::EulerMoreauOSI processIntegrator(new EulerMoreauOSI(theta));
-    processSimulation->insertIntegrator(processIntegrator);
-    process->nonSmoothDynamicalSystem()->topology()->setOSI(processDS,processIntegrator);
+    processSimulation->initializeOSIforDS(processIntegrator, processDS, process, t0);
 
     // -------------
     // --- Model controller ---
@@ -142,8 +141,9 @@ int main(int argc, char* argv[])
     // -- OneStepIntegrators --
     double controllertheta = 0.5;
     SP::EulerMoreauOSI controllerIntegrator(new EulerMoreauOSI(controllertheta));
-    controllerSimulation->insertIntegrator(controllerIntegrator);
-    controller->nonSmoothDynamicalSystem()->topology()->setOSI(controllerDS,controllerIntegrator);
+    controllerSimulation->initializeOSIforDS(controllerIntegrator, controllerDS,
+                                             controller, t0);
+
     // -- OneStepNsProblem --
     SP::LCP controllerLCP(new LCP());
 

--- a/examples/Mechanics/BouncingBall/BouncingBallTS.cpp
+++ b/examples/Mechanics/BouncingBall/BouncingBallTS.cpp
@@ -125,7 +125,6 @@ int main(int argc, char* argv[])
     // --- Simulation initialization ---
 
     cout << "====> Initialisation ..." << endl;
-    //bouncingBall->nonSmoothDynamicalSystem()->topology()->setOSI(ball, OSI);
     bouncingBall->initialize();
     cout << "====> Initialisation END ..." << endl;
 

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -289,13 +289,9 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
-    //OSI1->insertDynamicalSystem(beam1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-    //OSI2->insertDynamicalSystem(beam2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
 
@@ -306,6 +302,9 @@ int main(int argc, char* argv[])
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
     s->insertIntegrator(OSI2);
     s->insertIntegrator(OSI3);
+    s->initializeOSIforDS(OSI1, beam1, myModel, t0);
+    s->initializeOSIforDS(OSI2, beam2, myModel, t0);
+    s->initializeOSIforDS(OSI3, beam3, myModel, t0);
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -303,12 +303,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-    //OSI2->insertDynamicalSystem(beam2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -320,6 +316,9 @@ int main(int argc, char* argv[])
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
     s->insertIntegrator(OSI2);
     s->insertIntegrator(OSI3);
+    s->initializeOSIforDS(OSI1, beam1, myModel, t0);
+    s->initializeOSIforDS(OSI2, beam2, myModel, t0);
+    s->initializeOSIforDS(OSI3, beam3, myModel, t0);
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -309,13 +309,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
-    //OSI1->insertDynamicalSystem(beam1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-    //OSI2->insertDynamicalSystem(beam2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -327,6 +322,10 @@ int main(int argc, char* argv[])
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
     s->insertIntegrator(OSI2);
     s->insertIntegrator(OSI3);
+    s->initializeOSIforDS(OSI1, beam1, myModel, t0);
+    s->initializeOSIforDS(OSI2, beam2, myModel, t0);
+    s->initializeOSIforDS(OSI3, beam3, myModel, t0);
+
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -335,13 +335,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
-    //OSI1->insertDynamicalSystem(beam1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-    //OSI2->insertDynamicalSystem(beam2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -353,6 +348,10 @@ int main(int argc, char* argv[])
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
     s->insertIntegrator(OSI2);
     s->insertIntegrator(OSI3);
+    s->initializeOSIforDS(OSI1, beam1, myModel, t0);
+    s->initializeOSIforDS(OSI2, beam2, myModel, t0);
+    s->initializeOSIforDS(OSI3, beam3, myModel, t0);
+
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
@@ -316,14 +316,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-    //OSI2->insertDynamicalSystem(beam2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
-
-    //OSI3->insertDynamicalSystem(beam3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -334,9 +328,12 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-
     s->insertIntegrator(OSI2);
     s->insertIntegrator(OSI3);
+    s->initializeOSIforDS(OSI1, beam1, myModel, t0);
+    s->initializeOSIforDS(OSI2, beam2, myModel, t0);
+    s->initializeOSIforDS(OSI3, beam3, myModel, t0);
+
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1065,8 +1065,9 @@ class Hdf5():
             # add the dynamical system to the non smooth
             # dynamical system
             nsds = self._model.nonSmoothDynamicalSystem()
-            nsds.insertDynamicalSystem(body)
-            nsds.topology().setOSI(body, self._osi)
+            nsds.insertDynamicalSystem(body, self._model,
+                                       self._model.simulation().nextTime(),
+                                       self._osi)
             nsds.setName(body, str(name))
 
     def importBulletObject(self, name, translation, orientation,
@@ -1221,14 +1222,10 @@ class Hdf5():
                 if birth:
                     nsds = self._model.nonSmoothDynamicalSystem()
                     if use_proposed:
-                        nsds.insertDynamicalSystem(body)
-                        nsds.topology().setOSI(body, self._osi)
-                        nsds.topology().initDS(self._model,
-                            self._model.simulation().nextTime(),
-                            body, self._osi)
-                        #body.initialize(self._model.simulation().nextTime())
-                        self._model.simulation().initialize(
-                            self._model, False)
+                        nsds.insertDynamicalSystem(
+                            body, self._model, self._model.simulation().nextTime(),
+                            self._osi)
+                        self._model.simulation().initialize(self._model, False)
                     elif use_original:
                         self._broadphase.addDynamicObject(
                             body,
@@ -1237,8 +1234,7 @@ class Hdf5():
                     nsds.setName(body, str(name))
                 else:
                     nsds = self._model.nonSmoothDynamicalSystem()
-                    nsds.insertDynamicalSystem(body)
-                    nsds.topology().setOSI(body, self._osi)
+                    nsds.insertDynamicalSystem(body, self._model, 0, self._osi)
                     nsds.setName(body, str(name))
 
     def importJoint(self, name):

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1065,9 +1065,7 @@ class Hdf5():
             # add the dynamical system to the non smooth
             # dynamical system
             nsds = self._model.nonSmoothDynamicalSystem()
-            nsds.insertDynamicalSystem(body, self._model,
-                                       self._model.simulation().nextTime(),
-                                       self._osi)
+            nsds.insertDynamicalSystem(body)
             nsds.setName(body, str(name))
 
     def importBulletObject(self, name, translation, orientation,
@@ -1222,9 +1220,10 @@ class Hdf5():
                 if birth:
                     nsds = self._model.nonSmoothDynamicalSystem()
                     if use_proposed:
-                        nsds.insertDynamicalSystem(
-                            body, self._model, self._model.simulation().nextTime(),
-                            self._osi)
+                        nsds.insertDynamicalSystem(body)
+                        self._model.simulation().initializeOSIforDS(
+                            self._osi, body, self._model,
+                            self._model.simulation().nextTime())
                         self._model.simulation().initialize(self._model, False)
                     elif use_original:
                         self._broadphase.addDynamicObject(
@@ -1234,7 +1233,7 @@ class Hdf5():
                     nsds.setName(body, str(name))
                 else:
                     nsds = self._model.nonSmoothDynamicalSystem()
-                    nsds.insertDynamicalSystem(body, self._model, 0, self._osi)
+                    nsds.insertDynamicalSystem(body)
                     nsds.setName(body, str(name))
 
     def importJoint(self, name):

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
@@ -19,6 +19,7 @@
 #include "Interaction.hpp"
 #include "LagrangianLinearTIDS.hpp"
 #include "FirstOrderLinearTIDS.hpp"
+#include "OneStepIntegrator.hpp"
 #include "Relation.hpp"
 
 #include <SiconosConfig.h>
@@ -190,5 +191,22 @@ void NonSmoothDynamicalSystem::visitDynamicalSystems(SP::SiconosVisitor visitor)
   for (; dsi != dsiend; ++dsi)
   {
     dsg.bundle(*dsi)->acceptSP(visitor);
+  }
+}
+
+void NonSmoothDynamicalSystem::insertDynamicalSystem(SP::DynamicalSystem ds,
+                                                     SP::Model m, double time,
+                                                     SP::OneStepIntegrator osi)
+{
+  _topology->insertDynamicalSystem(ds);
+  _mIsLinear = ((ds)->isLinear() && _mIsLinear);
+
+  // If no OSI, or OSI has no DSG yet, assume DS will be initialized later.
+  // (Typically, during Simulation::initialize())
+  if (osi)
+  {
+    _topology->setOSI(ds, osi);
+    if (m && osi->dynamicalSystemsGraph())
+      osi->initializeDynamicalSystem(*m, time, ds);
   }
 }

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
@@ -194,19 +194,8 @@ void NonSmoothDynamicalSystem::visitDynamicalSystems(SP::SiconosVisitor visitor)
   }
 }
 
-void NonSmoothDynamicalSystem::insertDynamicalSystem(SP::DynamicalSystem ds,
-                                                     SP::Model m, double time,
-                                                     SP::OneStepIntegrator osi)
+void NonSmoothDynamicalSystem::insertDynamicalSystem(SP::DynamicalSystem ds)
 {
   _topology->insertDynamicalSystem(ds);
   _mIsLinear = ((ds)->isLinear() && _mIsLinear);
-
-  // If no OSI, or OSI has no DSG yet, assume DS will be initialized later.
-  // (Typically, during Simulation::initialize())
-  if (osi)
-  {
-    _topology->setOSI(ds, osi);
-    if (m && osi->dynamicalSystemsGraph())
-      osi->initializeDynamicalSystem(*m, time, ds);
-  }
 }

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.cpp
@@ -19,7 +19,6 @@
 #include "Interaction.hpp"
 #include "LagrangianLinearTIDS.hpp"
 #include "FirstOrderLinearTIDS.hpp"
-#include "OneStepIntegrator.hpp"
 #include "Relation.hpp"
 
 #include <SiconosConfig.h>
@@ -192,10 +191,4 @@ void NonSmoothDynamicalSystem::visitDynamicalSystems(SP::SiconosVisitor visitor)
   {
     dsg.bundle(*dsi)->acceptSP(visitor);
   }
-}
-
-void NonSmoothDynamicalSystem::insertDynamicalSystem(SP::DynamicalSystem ds)
-{
-  _topology->insertDynamicalSystem(ds);
-  _mIsLinear = ((ds)->isLinear() && _mIsLinear);
 }

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
@@ -109,13 +109,14 @@ public:
   }
 
   /** add a dynamical system into the DS graph (as a vertex)
+   * \param m The model
+   * \param time The time at which the DS is added
    * \param ds a pointer to the system to add
+   * \param osi a OneStepIntegrator for the DS
    */
-  inline void insertDynamicalSystem(SP::DynamicalSystem ds)
-  {
-    _topology->insertDynamicalSystem(ds);
-    _mIsLinear = ((ds)->isLinear() && _mIsLinear);
-  };
+  void insertDynamicalSystem(SP::DynamicalSystem ds, SP::Model m=SP::Model(),
+                             double time=0,
+                             SP::OneStepIntegrator osi=SP::OneStepIntegrator());
 
   /** get Dynamical system number I
    * \param nb the identifier of the DynamicalSystem to get

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
@@ -111,7 +111,11 @@ public:
   /** add a dynamical system into the DS graph (as a vertex)
    * \param ds a pointer to the system to add
    */
-  void insertDynamicalSystem(SP::DynamicalSystem ds);
+  inline void insertDynamicalSystem(SP::DynamicalSystem ds)
+  {
+    _topology->insertDynamicalSystem(ds);
+    _mIsLinear = ((ds)->isLinear() && _mIsLinear);
+  };
 
   /** get Dynamical system number I
    * \param nb the identifier of the DynamicalSystem to get

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
@@ -109,14 +109,9 @@ public:
   }
 
   /** add a dynamical system into the DS graph (as a vertex)
-   * \param m The model
-   * \param time The time at which the DS is added
    * \param ds a pointer to the system to add
-   * \param osi a OneStepIntegrator for the DS
    */
-  void insertDynamicalSystem(SP::DynamicalSystem ds, SP::Model m=SP::Model(),
-                             double time=0,
-                             SP::OneStepIntegrator osi=SP::OneStepIntegrator());
+  void insertDynamicalSystem(SP::DynamicalSystem ds);
 
   /** get Dynamical system number I
    * \param nb the identifier of the DynamicalSystem to get

--- a/kernel/src/simulationTools/D1MinusLinearOSI.cpp
+++ b/kernel/src/simulationTools/D1MinusLinearOSI.cpp
@@ -115,12 +115,8 @@ unsigned int D1MinusLinearOSI::numberOfIndexSets() const
 void D1MinusLinearOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
-  // Initialize memory buffers
-  // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
-  // // Force dynamical system to its initial state
-  // _dynamicalSystemsGraph->bundle(dsv)->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   // Check dynamical system type
   Type::Siconos dsType = Type::value(*ds);
   assert(dsType == Type::LagrangianLinearTIDS || dsType == Type::LagrangianDS || Type::NewtonEulerDS);

--- a/kernel/src/simulationTools/EulerMoreauOSI.cpp
+++ b/kernel/src/simulationTools/EulerMoreauOSI.cpp
@@ -96,13 +96,8 @@ SP::SiconosMatrix EulerMoreauOSI::WBoundaryConditions(SP::DynamicalSystem ds)
 
 void EulerMoreauOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
-  // Get work buffers from the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
-  // // Initialize memory buffers
-  // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
-  // // Force dynamical system to its initial state
-  // _dynamicalSystemsGraph->bundle(dsv)->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   // Check dynamical system type
   SP::FirstOrderNonLinearDS fods = std11::static_pointer_cast<FirstOrderNonLinearDS> (ds);
   Type::Siconos dsType = Type::value(*ds);

--- a/kernel/src/simulationTools/Hem5OSI.cpp
+++ b/kernel/src/simulationTools/Hem5OSI.cpp
@@ -482,12 +482,8 @@ void Hem5OSI::fprob(integer* IFCN,
 void Hem5OSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
-  // // Initialize memory buffers
-  // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
-  // // Force dynamical system to its initial state
-  // _dynamicalSystemsGraph->bundle(dsv)->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   Type::Siconos dsType = Type::value(*ds);
 
   if(dsType == Type::LagrangianDS || dsType == Type::LagrangianLinearTIDS)

--- a/kernel/src/simulationTools/LsodarOSI.cpp
+++ b/kernel/src/simulationTools/LsodarOSI.cpp
@@ -238,11 +238,8 @@ void LsodarOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSyste
 {
   DEBUG_BEGIN("LsodarOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n");
   // Get work buffers from the graph
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(_dynamicalSystemsGraph->descriptor(ds)).workVectors;
-  // // Initialize memory buffers
-  // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
-  // // Force dynamical system to its initial state
-  // _dynamicalSystemsGraph->bundle(dsv)->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   Type::Siconos dsType = Type::value(*ds);
 
   ds->initRhs(t); // This will create p[2] and other required vectors/buffers

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -78,7 +78,7 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const Model& m)
   _OSI.reset(new LsodarOSI());
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim.reset(new EventDriven(_TD, 0));
-  _sim->insertIntegrator(_OSI);
+  _sim->initializeOSIforDS(_OSI, _DS, _model, m.t0());
   _model->setSimulation(_sim);
   _model->initialize();
 

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -76,7 +76,7 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const Model& m)
   // integration stuff
   _model.reset(new Model(m.t0(), m.finalT()));
   _OSI.reset(new LsodarOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, m.t0(), _OSI);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim.reset(new EventDriven(_TD, 0));
   _sim->insertIntegrator(_OSI);
   _model->setSimulation(_sim);

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -76,8 +76,7 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const Model& m)
   // integration stuff
   _model.reset(new Model(m.t0(), m.finalT()));
   _OSI.reset(new LsodarOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _OSI);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, m.t0(), _OSI);
   _sim.reset(new EventDriven(_TD, 0));
   _sim->insertIntegrator(_OSI);
   _model->setSimulation(_sim);

--- a/kernel/src/simulationTools/MoreauJeanGOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanGOSI.cpp
@@ -67,12 +67,8 @@ MoreauJeanGOSI::MoreauJeanGOSI(double theta, double gamma):
 void MoreauJeanGOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
-  // Initialize memory buffers
-  // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
-  // // Force dynamical system to its initial state
-  // _dynamicalSystemsGraph->bundle(dsv)->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   // Check dynamical system type
   Type::Siconos dsType = Type::value(*ds);
 

--- a/kernel/src/simulationTools/MoreauJeanOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanOSI.cpp
@@ -99,22 +99,9 @@ SP::SiconosMatrix MoreauJeanOSI::WBoundaryConditions(SP::DynamicalSystem ds)
 }
 
 
-void MoreauJeanOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void MoreauJeanOSI::initializeDynamicalSystem(Model&, double t, SP::DynamicalSystem ds)
 {
-  // Create new work buffers, store in the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  SP::VectorOfVectors wv = std11::make_shared<VectorOfVectors>(
-    OneStepIntegrator::work_vector_of_vector_size);
-  SP::VectorOfMatrices wm = std11::make_shared<VectorOfMatrices>();
-  _dynamicalSystemsGraph->properties(dsv).workVectors = wv;
-  _dynamicalSystemsGraph->properties(dsv).workMatrices = wm;
-  VectorOfVectors& workVectors = *wv;
-
-  // Initialize memory buffers
-  ds->initMemory(getSizeMem());
-
-  // Force dynamical system to its initial state
-  ds->resetToInitialState();
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
 
   // Check dynamical system type
   Type::Siconos dsType = Type::value(*ds);
@@ -125,8 +112,6 @@ void MoreauJeanOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalS
 
   if(dsType == Type::LagrangianLinearTIDS || dsType == Type::LagrangianDS)
   {
-    assert(_dynamicalSystemsGraph->properties(dsv).W && "W is NULL");
-
     // buffers allocation (inside the graph)
     SP::LagrangianDS lds = std11::static_pointer_cast<LagrangianDS> (ds);
     workVectors[OneStepIntegrator::residu_free].reset(new SiconosVector(lds->dimension()));

--- a/kernel/src/simulationTools/NewMarkAlphaOSI.cpp
+++ b/kernel/src/simulationTools/NewMarkAlphaOSI.cpp
@@ -404,9 +404,12 @@ void NewMarkAlphaOSI::computeFreeOutput(InteractionsGraph::VDescriptor& vertex_i
 void NewMarkAlphaOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("NewMarkAlphaOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n")
-    // Get work buffers from the graph
-    const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
+
+  // Get work buffers from the graph
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
+  // Get work matrices from the graph
+  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
   VectorOfMatrices& workMatrices = *_dynamicalSystemsGraph->properties(dsv).workMatrices;
   // Initialize memory buffers
   // _dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());

--- a/kernel/src/simulationTools/OneStepIntegrator.hpp
+++ b/kernel/src/simulationTools/OneStepIntegrator.hpp
@@ -146,7 +146,13 @@ protected:
       \param inter a reference to an Interaction
   */
   void _check_and_update_interaction_levels(Interaction& inter);
-  
+
+  /** initialization of the work vectors and matrices (properties) related to
+   *  one dynamical system on the graph and needed by the osi -- common code.
+   * \param ds the dynamical system
+   */
+  SP::VectorOfVectors initializeDynamicalSystemWorkVectors(SP::DynamicalSystem ds);
+
 private:
 
 
@@ -252,7 +258,7 @@ public:
   /** Initialization process of the nonsmooth problems
    linked to this OSI*/
   virtual void initialize_nonsmooth_problems(){};
-  
+
   /** initialization of the work vectors and matrices (properties) related to
    *  one dynamical system on the graph and needed by the osi
    * \param m the Model

--- a/kernel/src/simulationTools/SchatzmanPaoliOSI.cpp
+++ b/kernel/src/simulationTools/SchatzmanPaoliOSI.cpp
@@ -99,9 +99,10 @@ SP::SiconosMatrix SchatzmanPaoliOSI::WBoundaryConditions(SP::DynamicalSystem ds)
 void SchatzmanPaoliOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("SchatzmanPaoliOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n");
+
   // Get work buffers from the graph
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
+
   // Check dynamical system type
   Type::Siconos dsType = Type::value(*ds);
   assert(dsType == Type::LagrangianLinearTIDS);

--- a/kernel/src/simulationTools/Simulation.cpp
+++ b/kernel/src/simulationTools/Simulation.cpp
@@ -497,3 +497,15 @@ void Simulation::updateOutput(unsigned int)
   }
   DEBUG_END("Simulation::updateOutput()\n");
 }
+
+void Simulation::initializeOSIforDS(SP::OneStepIntegrator osi,
+                                    SP::DynamicalSystem ds,
+                                    SP::Model m, double time)
+{
+  _nsds->topology()->setOSI(ds, osi);
+
+  // If no Model, or OSI has no DSG yet, assume DS will be initialized
+  // later.  (Typically, during Simulation::initialize())
+  if (m && osi->dynamicalSystemsGraph())
+    osi->initializeDynamicalSystem(*m, time, ds);
+}

--- a/kernel/src/simulationTools/Simulation.cpp
+++ b/kernel/src/simulationTools/Simulation.cpp
@@ -502,6 +502,10 @@ void Simulation::initializeOSIforDS(SP::OneStepIntegrator osi,
                                     SP::DynamicalSystem ds,
                                     SP::Model m, double time)
 {
+  // Keep OSI in the set, no effect if is already present.
+  insertIntegrator(osi);
+
+  // Associate the OSI to the DS in the topology.
   _nsds->topology()->setOSI(ds, osi);
 
   // If no Model, or OSI has no DSG yet, assume DS will be initialized

--- a/kernel/src/simulationTools/Simulation.hpp
+++ b/kernel/src/simulationTools/Simulation.hpp
@@ -385,6 +385,16 @@ public:
    *  topology updates. */
   virtual void initializeInteraction(double time, SP::Interaction inter);
 
+  /** Associate an OSI with a DynamicalSystem in the graph and
+   *  initialize any necessary graph properties.
+   *  \param osi The OneStepIntegrator to associate with the DynamicalSystem.
+   *  \param ds The DynamicalSystem, which must be already inserted
+   *            into the NonSmoothDynamicalSystem.
+   *  \param m The Model for initializing the OSI.
+   *  \param time The current time for initializing the OSI. */
+  void initializeOSIforDS(SP::OneStepIntegrator osi, SP::DynamicalSystem ds,
+                          SP::Model m, double time);
+
   /** Set an object to automatically manage interactions during the simulation */
   void insertInteractionManager(SP::InteractionManager manager)
     { _interman = manager; }

--- a/kernel/src/simulationTools/Topology.cpp
+++ b/kernel/src/simulationTools/Topology.cpp
@@ -20,23 +20,6 @@
 #include "NonSmoothDynamicalSystem.hpp"
 #include "Interaction.hpp"
 #include "EqualityConditionNSL.hpp"
-
-
-#include "MoreauJeanOSI.hpp"
-#include "MoreauJeanGOSI.hpp"
-#include "EulerMoreauOSI.hpp"
-#include "SchatzmanPaoliOSI.hpp"
-
-#define VISITOR_CLASSES() \
-  REGISTER(MoreauJeanOSI) \
-  REGISTER(MoreauJeanGOSI) \
-  REGISTER(EulerMoreauOSI) \
-  REGISTER(SchatzmanPaoliOSI)
-
-#include <VisitorMaker.hpp>
-using namespace Experimental;
-
-// to be removed, once the mess with allOSI and OSIDynamicalSystems has been cleaned -- xhub
 #include "OneStepIntegrator.hpp"
 
 #if (__cplusplus >= 201103L) && !defined(USE_BOOST_FOR_CXX11)
@@ -248,42 +231,6 @@ void Topology::setName(SP::Interaction inter, const std::string& name)
 {
   InteractionsGraph::VDescriptor igv = _IG[0]->descriptor(inter);
   _IG[0]->name.insert(igv, name);
-}
-
-/* initializeIterationMatrixW is not a member of OneStepIntegrator (should it be ?),
-   so we visit some integrators which provide this initialization.
-*/
-
-/* first, a generic visitor is defined. */
-struct CallInitDS : public SiconosVisitor
-{
-  double time;
-  SP::DynamicalSystem ds;
-  SP::Model m ; 
-  template<typename T>
-  void operator()(const T& osi)
-  {
-    const_cast<T*>(&osi)->initializeDynamicalSystem(*(this->m), this->time, this->ds);
-  }
-};
-
-/* the visit is made on classes which provide the function initializeIterationMatrixW */
-// typedef Visitor < Classes < MoreauJeanOSI >,
-//                   CallInitDS >::Make InitDynamicalSystem;
-
-typedef Visitor < Classes < MoreauJeanOSI,
-                            MoreauJeanGOSI,
-                            EulerMoreauOSI,
-                            SchatzmanPaoliOSI >,
-                  CallInitDS >::Make InitDynamicalSystem;
-
-void Topology::initDS(SP::Model m, double time, SP::DynamicalSystem ds, SP::OneStepIntegrator OSI)
-{
-  InitDynamicalSystem initDynamicalSystem;
-  initDynamicalSystem.time = 0;
-  initDynamicalSystem.ds = ds;
-  initDynamicalSystem.m = m;
-  OSI->accept(initDynamicalSystem);
 }
 
 void Topology::setOSI(SP::DynamicalSystem ds, SP::OneStepIntegrator OSI)

--- a/kernel/src/simulationTools/Topology.hpp
+++ b/kernel/src/simulationTools/Topology.hpp
@@ -159,8 +159,6 @@ public:
    */
   void setOSI(SP::DynamicalSystem ds, SP::OneStepIntegrator OSI);
 
-  void initDS(SP::Model m, double time, SP::DynamicalSystem ds, SP::OneStepIntegrator OSI);
-
    /** link two dynamical systems to a relation
    * \param inter a SP::Interaction
    * \param ds a SP::DynamicalSystem

--- a/kernel/src/simulationTools/ZeroOrderHoldOSI.cpp
+++ b/kernel/src/simulationTools/ZeroOrderHoldOSI.cpp
@@ -57,13 +57,13 @@ ZeroOrderHoldOSI::ZeroOrderHoldOSI():
 
 void ZeroOrderHoldOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
 {
+  // Get work buffers from the graph
+  VectorOfVectors& workVectors = *initializeDynamicalSystemWorkVectors(ds);
 
   DynamicalSystemsGraph& DSG0 = *_dynamicalSystemsGraph;
   InteractionsGraph& IG0 = *_simulation->nonSmoothDynamicalSystem()->topology()->indexSet0();
-  const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);
+
   Type::Siconos dsType = Type::value(*ds);
-  // Initialize memory buffers
-  //_dynamicalSystemsGraph->bundle(dsv)->initMemory(getSizeMem());
 
   if((dsType != Type::FirstOrderLinearDS) && (dsType != Type::FirstOrderLinearTIDS))
     RuntimeException::selfThrow("ZeroOrderHoldOSI::initialize - the DynamicalSystem does not have the right type");
@@ -130,7 +130,6 @@ void ZeroOrderHoldOSI::initializeDynamicalSystem(Model& m, double t, SP::Dynamic
   }
 
   // Get work buffers from the graph
-  VectorOfVectors& workVectors = *_dynamicalSystemsGraph->properties(dsv).workVectors;
   workVectors.resize(OneStepIntegrator::work_vector_of_vector_size);
   workVectors[OneStepIntegrator::free].reset(new SiconosVector(ds->dimension()));
 }

--- a/kernel/src/simulationTools/test/OSNSPTest.cpp
+++ b/kernel/src/simulationTools/test/OSNSPTest.cpp
@@ -39,8 +39,7 @@ void OSNSPTest::init()
   _model.reset(new Model(_t0, _T));
   _sim.reset(new TimeStepping(_TD, 0));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _osi);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _osi);
   _sim->insertIntegrator(_osi);
   _model->setSimulation(_sim);
   _model->initialize();
@@ -88,8 +87,7 @@ void OSNSPTest::testAVI()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _osi);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _osi);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _sim.reset(new TimeStepping(_TD));
   _sim->insertIntegrator(_osi);

--- a/kernel/src/simulationTools/test/OSNSPTest.cpp
+++ b/kernel/src/simulationTools/test/OSNSPTest.cpp
@@ -37,10 +37,10 @@ void OSNSPTest::init()
   _DS.reset(new FirstOrderLinearTIDS(_x0, _A, _b));
   _TD.reset(new TimeDiscretisation(_t0, _h));
   _model.reset(new Model(_t0, _T));
-  _sim.reset(new TimeStepping(_TD, 0));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _osi);
-  _sim->insertIntegrator(_osi);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _sim.reset(new TimeStepping(_TD, 0));
+  _sim->initializeOSIforDS(_osi, _DS, _model, _t0);
   _model->setSimulation(_sim);
   _model->initialize();
 }
@@ -87,10 +87,10 @@ void OSNSPTest::testAVI()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _osi);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _sim.reset(new TimeStepping(_TD));
-  _sim->insertIntegrator(_osi);
+  _sim->initializeOSIforDS(_osi, _DS, _model, _t0);
   SP::AVI osnspb(new AVI());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);

--- a/kernel/src/simulationTools/test/ZOHTest.cpp
+++ b/kernel/src/simulationTools/test/ZOHTest.cpp
@@ -39,8 +39,7 @@ void ZOHTest::init()
   _model.reset(new Model(_t0, _T));
   _sim.reset(new TimeStepping(_TD, 0));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
   _sim->insertIntegrator(_ZOH);
   _model->setSimulation(_sim);
   _model->initialize();
@@ -158,8 +157,7 @@ void ZOHTest::testMatrixIntegration2()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
@@ -226,8 +224,7 @@ void ZOHTest::testMatrixIntegration3()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
@@ -300,8 +297,7 @@ void ZOHTest::testMatrixIntegration4()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _model->nonSmoothDynamicalSystem()->topology()->setOSI(_DS, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));

--- a/kernel/src/simulationTools/test/ZOHTest.cpp
+++ b/kernel/src/simulationTools/test/ZOHTest.cpp
@@ -39,7 +39,7 @@ void ZOHTest::init()
   _model.reset(new Model(_t0, _T));
   _sim.reset(new TimeStepping(_TD, 0));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim->insertIntegrator(_ZOH);
   _model->setSimulation(_sim);
   _model->initialize();

--- a/kernel/src/simulationTools/test/ZOHTest.cpp
+++ b/kernel/src/simulationTools/test/ZOHTest.cpp
@@ -40,7 +40,7 @@ void ZOHTest::init()
   _sim.reset(new TimeStepping(_TD, 0));
   _ZOH.reset(new ZeroOrderHoldOSI());
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _sim->insertIntegrator(_ZOH);
+  _sim->initializeOSIforDS(_DS, _ZOH, _model, _t0);
   _model->setSimulation(_sim);
   _model->initialize();
 }
@@ -157,11 +157,11 @@ void ZOHTest::testMatrixIntegration2()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->insertIntegrator(_ZOH);
+  _sim->initializeOSIforDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);
@@ -224,11 +224,11 @@ void ZOHTest::testMatrixIntegration3()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->insertIntegrator(_ZOH);
+  _sim->initializeOSIforDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);
@@ -297,11 +297,11 @@ void ZOHTest::testMatrixIntegration4()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _model, _t0, _ZOH);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->insertIntegrator(_ZOH);
+  _sim->initializeOSIforDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);

--- a/kernel/swig/fromXml.py.in
+++ b/kernel/swig/fromXml.py.in
@@ -421,8 +421,7 @@ def buildModelXML(xmlFile):
             _additionalInputsOSI(osixml, osi, dataOSI[osiType])
             print(osixml.DS_Concerned)
             for dsN in osixml.DS_Concerned:
-                model.nonSmoothDynamicalSystem().topology().setOSI(allDS[dsN], osi)
-            sim.insertIntegrator(osi)
+                sim.initializeOSIforDS(osi, allDS[dsN], model, sim.nextTime())
             allOSI.append(osi)
 
     # OSNSPB

--- a/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
+++ b/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
@@ -508,19 +508,8 @@ void BulletSpaceFilter::addDynamicObject(SP::BulletDS ds,
   }
 
   /* Insert the new DS into the OSI, model, and simulation. */
-  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
-  this->model()->nonSmoothDynamicalSystem()->topology()->setOSI(ds, osi);
-
-  DynamicalSystemsGraph& dsg = *(this->model()->nonSmoothDynamicalSystem()->dynamicalSystems());
-  
-  InitDynamicalSystem initDS;
-  initDS.time = simulation->nextTime();
-  initDS.ds = ds;
-  initDS.m= this->model();
-  osi->accept(initDS);
-
-  // /* Initialize the DS at the current time */
-  // ds->initialize(simulation->nextTime(), osi->getSizeMem());
+  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(
+    ds, this->model(), simulation->nextTime(), osi);
 
   /* Partially re-initialize the simulation. */
   simulation->initialize(this->model(), false);

--- a/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
+++ b/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
@@ -508,8 +508,10 @@ void BulletSpaceFilter::addDynamicObject(SP::BulletDS ds,
   }
 
   /* Insert the new DS into the OSI, model, and simulation. */
-  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(
-    ds, this->model(), simulation->nextTime(), osi);
+  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
+
+  /* Associate/initialize the OSI */
+  simulation->initializeOSIforDS(osi, ds, this->model(), simulation->nextTime());
 
   /* Partially re-initialize the simulation. */
   simulation->initialize(this->model(), false);

--- a/mechanics/src/collision/bullet/test/ContactTest.cpp
+++ b/mechanics/src/collision/bullet/test/ContactTest.cpp
@@ -208,7 +208,7 @@ BounceResult bounceTest(std::string moving,
     body->setFExtPtr(FExt);
 
     // -- Add the dynamical systems into the non smooth dynamical system
-    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
+    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, model, t0, osi);
 
     // -- Time discretisation --
     SP::TimeDiscretisation timedisc(new TimeDiscretisation(t0, h));

--- a/mechanics/src/collision/bullet/test/ContactTest.cpp
+++ b/mechanics/src/collision/bullet/test/ContactTest.cpp
@@ -208,7 +208,7 @@ BounceResult bounceTest(std::string moving,
     body->setFExtPtr(FExt);
 
     // -- Add the dynamical systems into the non smooth dynamical system
-    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, model, t0, osi);
+    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
 
     // -- Time discretisation --
     SP::TimeDiscretisation timedisc(new TimeDiscretisation(t0, h));

--- a/mechanics/src/collision/native/test/MultiBodyTest.cpp
+++ b/mechanics/src/collision/native/test/MultiBodyTest.cpp
@@ -254,7 +254,7 @@ void Disks::init(std::string disks_input)
       body->setFExtPtr(FExt);
 
       // add the dynamical system in the non smooth dynamical system
-      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, _model, t0, osi);
+      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
     }
 
 

--- a/mechanics/src/collision/native/test/MultiBodyTest.cpp
+++ b/mechanics/src/collision/native/test/MultiBodyTest.cpp
@@ -254,9 +254,7 @@ void Disks::init(std::string disks_input)
       body->setFExtPtr(FExt);
 
       // add the dynamical system in the non smooth dynamical system
-      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
-      _model->nonSmoothDynamicalSystem()->topology()->setOSI(body, osi);
-
+      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, _model, t0, osi);
     }
 
 


### PR DESCRIPTION
[kernel] Move all DS insertion and initialization to NSDS::insertDynamicalSystem()

This is an attempt to address issues raised in #119.  Any comments appreciated, it if it's ok to merge it relatively quickly it would resolve some initialization issues across OSIs in one go.

Basically, this proposes to move all DS working memory initialization to OSI::initializeDynamicalSystem, and call that from NonSmoothDynamicalSystem::insertDynamicalSystem, which then does all the work to insert the DS, set the OSI, and initialize the memory.  Common code across OSIs is shared in an internal function in OneStepIntegrator.

Comments requested for whether the NSDS is a good place to do this.  My argument is that Topology() just manipulates the graph and so should do little work, but the NSDS is responsible to manipulate the Topology, so maybe it is okay if it knows how to associate a DS and an OSI, and initialize a DS according to the OSI.  The other candidate to do this would be the Simulation.
