### PR TITLE
Fix OCC.

### DIFF
--- a/mechanics/src/mechanisms/CADMBTB/mymath_FunctionSetRoot.cxx
+++ b/mechanics/src/mechanisms/CADMBTB/mymath_FunctionSetRoot.cxx
@@ -202,7 +202,8 @@ static Standard_Boolean MinimizeDirection(const math_Vector&   P0,
   ax = -1; bx = 0;
   cx = (P2-P1).Norm()*invnorme;
   if (cx < 1.e-2) return Standard_False;
-  math_BrentMinimum Sol(F, ax, bx, cx, tol1d, 100, tol1d);
+  math_BrentMinimum Sol(tol1d, 100, tol1d);
+  Sol.Perform(F, ax, bx, cx);
   if(Sol.IsDone()) {
     tsol = Sol.Location();
     if (Sol.Minimum() < F1) {
@@ -295,7 +296,8 @@ static Standard_Boolean MinimizeDirection(const math_Vector&   P,
       ax = 0.0; bx = tsol; cx = 1.0;
     }
     if (mydebug) cout << " minimisation dans la direction" << endl;
-    math_BrentMinimum Sol(F, ax, bx, cx, tol1d, 100, tol1d);
+    math_BrentMinimum Sol(tol1d, 100, tol1d);
+    Sol.Perform(F, ax, bx, cx);
     if(Sol.IsDone()) {
       if (Sol.Minimum() <= Result) {
 	tsol = Sol.Location();

--- a/mechanics/src/occ/Geometer.hpp
+++ b/mechanics/src/occ/Geometer.hpp
@@ -62,7 +62,11 @@ void distanceFaceFace<CadmbtbDistanceType>(const OccContactFace& csh1,
                                    Standard_Real& X2, Standard_Real& Y2, Standard_Real& Z2,
                                    Standard_Real& nX, Standard_Real& nY, Standard_Real& nZ,
                                    bool normalFromFace1,
-                                   Standard_Real& MinDist);
+                                   Standard_Real& MinDist)
+{
+  cadmbtb_distanceFaceFace(csh1, csh2, X1, Y1, Z1, X2, Y2, Z2, nX, nY, nZ,
+			   normalFromFace1, MinDist);
+}
 
 template<>
 void distanceFaceEdge<CadmbtbDistanceType>(const OccContactFace& csh1,
@@ -71,7 +75,11 @@ void distanceFaceEdge<CadmbtbDistanceType>(const OccContactFace& csh1,
                                    Standard_Real& X2, Standard_Real& Y2, Standard_Real& Z2,
                                    Standard_Real& nX, Standard_Real& nY, Standard_Real& nZ,
                                    bool normalFromFace1,
-                                   Standard_Real& MinDist);
+                                   Standard_Real& MinDist)
+{
+  cadmbtb_distanceFaceEdge(csh1, csh2, X1, Y1, Z1, X2, Y2, Z2, nX, nY, nZ,
+			   normalFromFace1, MinDist);
+}
 
 
 template<>
@@ -81,7 +89,11 @@ void distanceFaceFace<OccDistanceType>(const OccContactFace& csh1,
                                Standard_Real& X2, Standard_Real& Y2, Standard_Real& Z2,
                                Standard_Real& nX, Standard_Real& nY, Standard_Real& nZ,
                                bool normalFromFace1,
-                               Standard_Real& MinDist);
+                               Standard_Real& MinDist)
+{
+  occ_distanceFaceFace(csh1, csh2, X1, Y1, Z1, X2, Y2, Z2, nX, nY, nZ,
+		       normalFromFace1, MinDist);
+}
 
 template<>
 void distanceFaceEdge<OccDistanceType>(const OccContactFace& csh1,
@@ -90,7 +102,11 @@ void distanceFaceEdge<OccDistanceType>(const OccContactFace& csh1,
                                Standard_Real& X2, Standard_Real& Y2, Standard_Real& Z2,
                                Standard_Real& nX, Standard_Real& nY, Standard_Real& nZ,
                                bool normalFromFace1,
-                               Standard_Real& MinDist);
+                               Standard_Real& MinDist)
+{
+  occ_distanceFaceEdge(csh1, csh2, X1, Y1, Z1, X2, Y2, Z2, nX, nY, nZ,
+		       normalFromFace1, MinDist);
+}
 
 template <typename DistType>
 struct FaceGeometer : public Geometer

--- a/mechanics/src/occ/OccBody.cpp
+++ b/mechanics/src/occ/OccBody.cpp
@@ -19,8 +19,18 @@ void OccBody::addContactShape(SP::OccContactShape shape,
                               SP::SiconosVector ori,
                               unsigned int group)
 {
-  OffSet offset = { {(*pos)(0), (*pos)(1), (*pos)(2),
-                     (*ori)(0), (*ori)(1), (*ori)(2), (*ori)(3)}};
+  OffSet offset = {0, 0, 0, 1, 0, 0 ,0};
+  if (pos) {
+    offset[0] = (*pos)(0);
+    offset[1] = (*pos)(1);
+    offset[2] = (*pos)(2);
+  }
+  if (ori) {
+    offset[3] = (*ori)(0);
+    offset[4] = (*ori)(1);
+    offset[5] = (*ori)(2);
+    offset[6] = (*ori)(3);
+  }
 
   this->_contactShapes->push_back(
     boost::tuple<SP::OccContactShape, OffSet, int>(shape, offset, group));
@@ -33,9 +43,18 @@ void OccBody::addShape(SP::TopoDS_Shape shape,
                        SP::SiconosVector pos,
                        SP::SiconosVector ori)
 {
-
-  OffSet offset = { {(*pos)(0), (*pos)(1), (*pos)(2),
-                     (*ori)(0), (*ori)(1), (*ori)(2), (*ori)(3)}};
+  OffSet offset = {0, 0, 0, 1, 0, 0 ,0};
+  if (pos) {
+    offset[0] = (*pos)(0);
+    offset[1] = (*pos)(1);
+    offset[2] = (*pos)(2);
+  }
+  if (ori) {
+    offset[3] = (*ori)(0);
+    offset[4] = (*ori)(1);
+    offset[5] = (*ori)(2);
+    offset[6] = (*ori)(3);
+  }
 
   this->_shapes->push_back(
     boost::tuple<SP::TopoDS_Shape, OffSet>(shape, offset));

--- a/mechanics/src/occ/test/OccTest.cpp
+++ b/mechanics/src/occ/test/OccTest.cpp
@@ -199,7 +199,7 @@ void OccTest::distance()
   std::cout << translat2.X() << "," << translat2.Y() << "," << translat2.Z()
             << std::endl;
 
-  SP::Geometer geometer = ask<WhichGeometer<CadmbtbType> >(body1->contactShape(0));
+  SP::Geometer geometer = ask<WhichGeometer<CadmbtbDistanceType> >(body1->contactShape(0));
 
   body2->contactShape(0).accept(*geometer);
 


### PR DESCRIPTION
I have never been able to get OCC/mechanisms to compile, let alone get the tests running. So I finally decided to check it out.  These were the changes I had to make.  The only one I am not sure about is the call to math_BrentMinimum, which seems to be different from the API specified for either OCC [6.9.0](https://www.opencascade.com/doc/occt-6.9.0/refman/html/classmath___brent_minimum.html) or [7.1.0](https://www.opencascade.com/doc/occt-7.1.0/refman/html/classmath___brent_minimum.html).

For users of mechanisms, please check that this doesn't break something, maybe it was different on old versions.  The environment I have used for testing is from https://github.com/siconos/siconos-tutorials/blob/master/Dockerfile-with-mechanisms and therefore uses OCE and PythonOCC from github.