### PR TITLE
joints construction: points and axes in superclass, allow deferred init

### DIFF
--- a/examples/Mechanics/JointsTests/NE_1DS_1Knee_MLCP.cpp
+++ b/examples/Mechanics/JointsTests/NE_1DS_1Knee_MLCP.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
 
     SP::Interaction inter1(new Interaction(nslaw1, relation1));
@@ -294,7 +294,7 @@ int main(int argc, char* argv[])
     std::cout << "Error w.r.t. reference file : " << (dataPlot - dataPlotRef).normInf() << std::endl;
     if ((dataPlot - dataPlotRef).normInf() > 1e-7)
     {
-      (dataPlot - dataPlotRef).display();
+      //(dataPlot - dataPlotRef).display();
       std::cout << "Warning. The results is rather different from the reference file." << std::endl;
       return 1;
     }

--- a/examples/Mechanics/JointsTests/NE_1DS_1Knee_MLCP_MoreauJeanCombinedProjection.cpp
+++ b/examples/Mechanics/JointsTests/NE_1DS_1Knee_MLCP_MoreauJeanCombinedProjection.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
 
     SP::Interaction inter1(new Interaction(nslaw1, relation1));

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -229,15 +229,15 @@ int main(int argc, char* argv[])
     SP::SiconosVector P(new SiconosVector(3));
     P->zero();
 
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
 
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
 
     SP::SimpleMatrix H1(new SimpleMatrix(relation1->numberOfConstraints(), qDim));
     H1->zero();
@@ -255,7 +255,7 @@ int main(int argc, char* argv[])
      SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
     SP::SimpleMatrix H4(new SimpleMatrix(relation4->numberOfConstraints(), qDim));
     H4->zero();
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
     // Building the second knee joint for beam1 and beam2
     // input  - the first concerned DS : beam1
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
 
     // Building the third knee joint for beam2 and beam3
     // input  - the first concerned DS : beam2
@@ -249,7 +249,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
 
 
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
     // relation1->setJachq(H1); // Remark V.A. Why do we need to set the Jacobian outside
     // relation2->setJachq(H2);
     // relation3->setJachq(H3);

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
 
 
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
 
     // Building the third knee joint for beam2 and beam3
     // input  - the first concerned DS : beam2
@@ -261,7 +261,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
 
 
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
     // relation1->setJachq(H1); // Remark V.A. Why do we need to set the Jacobian outside
     // relation2->setJachq(H2);
     // relation3->setJachq(H3);

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -249,15 +249,15 @@ int main(int argc, char* argv[])
     SP::SiconosVector P(new SiconosVector(3));
     P->zero();
 
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
     SP::SiconosVector G20(new SiconosVector(3));
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
 
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
     SP::NonSmoothLaw nslaw2(new EqualityConditionNSL(relation2->numberOfConstraints()));
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
 
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));
 

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
 
 
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
 
     // Building the third knee joint for beam2 and beam3
     // input  - the first concerned DS : beam2
@@ -284,8 +284,8 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
-    
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
+
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
     SP::NonSmoothLaw nslaw2(new EqualityConditionNSL(relation2->numberOfConstraints()));
     SP::NonSmoothLaw nslaw3(new EqualityConditionNSL(relation3->numberOfConstraints()));
@@ -298,7 +298,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));
 
     SP::Interaction inter1(new Interaction(nslaw1, relation1));

--- a/examples/Mechanics/JointsTestsWithContactDetection/pivot_stop.py
+++ b/examples/Mechanics/JointsTestsWithContactDetection/pivot_stop.py
@@ -59,7 +59,7 @@ with Hdf5() as io:
     # Connect the two bodies by a pivot joint
     io.addJoint('joint1', 'bar', 'post', [-0.45,0,0], [0,1,0], 'PivotJointR',
                 allow_self_collide = self_collide,
-                nslaws='stop', stops=stops)
+                nslaws='stop', stops=stops, absolute=False)
 
     # Joint from "bar" to the world reference frame, to keep things from falling.
     io.addJoint('joint2', 'post', None, [0,0,0], [0,1,0],

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_1DS_1Knee_MLCP_withSprings.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_1DS_1Knee_MLCP_withSprings.cpp
@@ -246,7 +246,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
     // // relation4->setJachq(H4);
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
     // Building the first knee joint for beam1
     // input  - the concerned DS : beam1
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
-    SP::KneeJointR relation1(new KneeJointR(beam1, P));
+    SP::KneeJointR relation1(new KneeJointR(P, true, beam1));
 
 
 
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, L1 / 2);
-    SP::KneeJointR relation2(new KneeJointR(beam1, beam2, P));
+    SP::KneeJointR relation2(new KneeJointR(P, false, beam1, beam2));
 
     // Building the third knee joint for beam2 and beam3
     // input  - the first concerned DS : beam2
@@ -261,7 +261,7 @@ int main(int argc, char* argv[])
     //        - a point in the spatial frame (absolute frame) where the knee is defined P
     P->zero();
     P->setValue(0, -L1 / 2);
-    SP::KneeJointR relation3(new KneeJointR(beam2, beam3, P));
+    SP::KneeJointR relation3(new KneeJointR(P, false, beam2, beam3));
 
     SP::NonSmoothLaw nslaw1(new EqualityConditionNSL(relation1->numberOfConstraints()));
     SP::NonSmoothLaw nslaw2(new EqualityConditionNSL(relation2->numberOfConstraints()));
@@ -274,7 +274,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(0, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(beam3, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, beam3));
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));
 
     SP::Interaction inter1(new Interaction(nslaw1, relation1));

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_BouncingBeam.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_BouncingBeam.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
     axe1->zero();
     axe1->setValue(2, 1);
 
-    SP::PrismaticJointR relation4(new PrismaticJointR(bouncingbeam, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, bouncingbeam));
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));
     SP::Interaction inter4(new Interaction(nslaw4, relation4));
     SP::Interaction interFloor(new Interaction(nslaw0, relation0));

--- a/io/src/SiconosFullGenerated.hpp
+++ b/io/src/SiconosFullGenerated.hpp
@@ -694,7 +694,7 @@ SICONOS_IO_REGISTER_WITH_BASES(ExternalBody,(LagrangianDS),
 )
 SICONOS_IO_REGISTER_WITH_BASES(Circle,(CircularDS),
 )
-SICONOS_IO_REGISTER_WITH_BASES(FixedJointR,(NewtonEulerR),
+SICONOS_IO_REGISTER_WITH_BASES(FixedJointR,(NewtonEulerJointR),
   (_G10G20d1x)
   (_G10G20d1y)
   (_G10G20d1z)
@@ -711,7 +711,10 @@ SICONOS_IO_REGISTER_WITH_BASES(KneeJointR,(NewtonEulerJointR),
   (_G2P0z)
   (_P0))
 SICONOS_IO_REGISTER_WITH_BASES(NewtonEulerJointR,(NewtonEulerR),
-  (_allowSelfCollide))
+  (_absoluteRef)
+  (_allowSelfCollide)
+  (_axes)
+  (_points))
 SICONOS_IO_REGISTER_WITH_BASES(SphereLDS,(LagrangianDS),
   (I)
   (massValue)

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1254,8 +1254,7 @@ class Hdf5():
 
             joint_type = self.joints()[name].attrs['type']
             joint_class = getattr(joints, joint_type)
-            absolute = self.joints()[name].attrs.get('absolute', None)
-            absolute = [[True if absolute else False], []][absolute is None]
+            absolute = not not self.joints()[name].attrs.get('absolute', True)
             allow_self_collide = self.joints()[name].attrs.get(
                 'allow_self_collide',None)
             stops = self.joints()[name].attrs.get('stops',None)
@@ -1270,31 +1269,30 @@ class Hdf5():
                 ds2_name = self.joints()[name].attrs['object2']
                 ds2 = topo.getDynamicalSystem(ds2_name)
                 try:
-                    joint = joint_class(ds1, ds2,
-                                        self.joints()[name].attrs['pivot_point'],
+                    joint = joint_class(self.joints()[name].attrs['pivot_point'],
                                         self.joints()[name].attrs['axis'],
-                                        *absolute)
+                                        absolute, ds1, ds2)
                 except NotImplementedError:
                     try:
-                        joint = joint_class(ds1, ds2,
-                                            self.joints()[name].attrs['pivot_point'],
-                                            *absolute)
+                        joint = joint_class(self.joints()[name].attrs['pivot_point'],
+                                            absolute, ds1, ds2)
                     except NotImplementedError:
-                        joint = joint_class(ds1, ds2, *absolute)
+                        joint = joint_class(absolute, ds1, ds2)
 
             else:
                 try:
-                    joint = joint_class(ds1,
-                                        self.joints()[name].attrs['pivot_point'],
+                    joint = joint_class(self.joints()[name].attrs['pivot_point'],
                                         self.joints()[name].attrs['axis'],
-                                        *absolute)
+                                        absolute, ds1)
                 except NotImplementedError:
                     try:
-                        joint = joint_class(ds1,
-                                            self.joints()[name].attrs['pivot_point'],
-                                            *absolute)
+                        joint = joint_class(self.joints()[name].attrs['pivot_point'],
+                                            absolute, ds1)
                     except NotImplementedError:
-                        joint = joint_class(ds1, *absolute)
+                        try:
+                            joint = joint_class(absolute, ds1)
+                        except NotImplementedError:
+                            joint = joint_class(ds1)
 
             if allow_self_collide is not None:
                 joint.setAllowSelfCollide(not not allow_self_collide)

--- a/mechanics/src/joints/CylindricalJointR.hpp
+++ b/mechanics/src/joints/CylindricalJointR.hpp
@@ -42,7 +42,6 @@ protected:
   ACCEPT_SERIALIZATION(CylindricalJointR);
   CylindricalJointR(): NewtonEulerJointR() {};
 
-public:
   /** Axis of the cylindrical point in the inertial frame of reference
    */
   SP::SiconosVector _axis0;
@@ -78,31 +77,25 @@ public:
   double _previousAngle; // Needed to track _twistCount, TODO: work vector?
   double _initialAngle;
 
-  /** constructor from two dynamical systems and an axis
-   *  \param d1 first  DynamicalSystem link by the  joint
-   *  \param d2 second  DynamicalSystem link by the joint
-   *  \param A SiconosVector of size 3 that defines the cylindrical axis
-   *           in the body frame of d1
-   */
-  CylindricalJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2,
-                    SP::SiconosVector P, SP::SiconosVector A,
-                    bool absoluteRef = false);
+public:
 
-  /** constructor from one dynamical systems and an axis
-   *  \param d1 the  DynamicalSystem link by the  joint
+  /** Constructor based on one or two dynamical systems, a point and an axis.
+   *  \param d1 first DynamicalSystem linked by the joint.
+   *  \param d2 second DynamicalSystem linked by the joint, or NULL
+   *            for absolute frame.
    *  \param P SiconosVector of size 3 that defines the point around
-   *           which rotation is allowed
-   *  \param A SiconosVector of size 3 that defines the cylindrical axis
-   *           in the inertial frame of reference
-   *  \param absoluteRef if true, P is in the absolute frame,
-   *                     otherwise P is in d1 frame
+   *           which rotation is allowed.
+   *  \param A SiconosVector of size 3 that defines the cylindrical axis.
+   *  \param absoluteRef if true, P and A are in the absolute frame,
+   *                     otherwise P and A are in d1 frame.
    */
-  CylindricalJointR(SP::NewtonEulerDS d1,
-                    SP::SiconosVector P, SP::SiconosVector A,
-                    bool absoluteRef = false);
+  CylindricalJointR(SP::SiconosVector P, SP::SiconosVector A, bool absoluteRef,
+                    SP::NewtonEulerDS d1 = SP::NewtonEulerDS(),
+                    SP::NewtonEulerDS d2 = SP::NewtonEulerDS());
 
-  void computeFromInitialPosition(SP::SiconosVector q2,
-                                  SP::SiconosVector q1=SP::SiconosVector());
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2 = SP::SiconosVector());
 
   void computeV1V2FromAxis();
 

--- a/mechanics/src/joints/FixedJointR.cpp
+++ b/mechanics/src/joints/FixedJointR.cpp
@@ -59,40 +59,17 @@
  */
 
 FixedJointR::FixedJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2)
-  : NewtonEulerR()
+  : NewtonEulerJointR()
 {
-  ::boost::math::quaternion<double> q1((*d1->q())(3), (*d1->q())(4),
-                                       (*d1->q())(5), (*d1->q())(6));
-  ::boost::math::quaternion<double> q2((*d2->q())(3), (*d2->q())(4),
-                                       (*d2->q())(5), (*d2->q())(6));
-  ::boost::math::quaternion<double> cq2q10(1.0 / q2 * q1);
-
-  _cq2q101 = cq2q10.R_component_1();
-  _cq2q102 = cq2q10.R_component_2();
-  _cq2q103 = cq2q10.R_component_3();
-  _cq2q104 = cq2q10.R_component_4();
-
-  ::boost::math::quaternion<double>    quatG10G20_abs(
-    0, d2->q()->getValue(0) - d1->q()->getValue(0),
-    d2->q()->getValue(1) - d1->q()->getValue(1),
-    d2->q()->getValue(2) - d1->q()->getValue(2));
-  ::boost::math::quaternion<double>    quatBuff(0, 0, 0, 0);
-
-  quatBuff = 1.0/q1 * quatG10G20_abs * q1;
-  _G10G20d1x = quatBuff.R_component_2();
-  _G10G20d1y = quatBuff.R_component_3();
-  _G10G20d1z = quatBuff.R_component_4();
+  setInitialConditions(d1->q(), d2 ? d2->q() : SP::SiconosVector());
 }
 
-/* constructor,
-   \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-*/
-FixedJointR::FixedJointR(SP::NewtonEulerDS d1)
-  : NewtonEulerR()
+void FixedJointR::setInitialConditions(SP::SiconosVector q1, SP::SiconosVector q2)
 {
-  ::boost::math::quaternion<double> q1((*d1->q())(3), (*d1->q())(4),
-                                       (*d1->q())(5), (*d1->q())(6));
-  ::boost::math::quaternion<double> cq2q10(q1);
+  ::boost::math::quaternion<double> quat1((*q1)(3), (*q1)(4), (*q1)(5), (*q1)(6));
+  ::boost::math::quaternion<double> quat2(q2 ? (*q2)(3) : 1, q2 ? (*q2)(4) : 0,
+                                          q2 ? (*q2)(5) : 0, q2 ? (*q2)(6) : 0);
+  ::boost::math::quaternion<double> cq2q10(1.0 / quat2 * quat1);
 
   _cq2q101 = cq2q10.R_component_1();
   _cq2q102 = cq2q10.R_component_2();
@@ -100,10 +77,12 @@ FixedJointR::FixedJointR(SP::NewtonEulerDS d1)
   _cq2q104 = cq2q10.R_component_4();
 
   ::boost::math::quaternion<double>    quatG10G20_abs(
-    0, - d1->q()->getValue(0), - d1->q()->getValue(1), - d1->q()->getValue(2));
+    0, (q2 ? q2->getValue(0) : 0) - q1->getValue(0),
+    (q2 ? q2->getValue(1) : 0) - q1->getValue(1),
+    (q2 ? q2->getValue(2) : 0) - q1->getValue(2));
   ::boost::math::quaternion<double>    quatBuff(0, 0, 0, 0);
 
-  quatBuff = 1.0/q1 * quatG10G20_abs * q1;
+  quatBuff = 1.0/quat1 * quatG10G20_abs * quat1;
   _G10G20d1x = quatBuff.R_component_2();
   _G10G20d1y = quatBuff.R_component_3();
   _G10G20d1z = quatBuff.R_component_4();

--- a/mechanics/src/joints/FixedJointR.hpp
+++ b/mechanics/src/joints/FixedJointR.hpp
@@ -22,48 +22,54 @@
 
 #include <MechanicsFwd.hpp>
 #include <SiconosFwd.hpp>
-#include <NewtonEulerR.hpp>
+#include <NewtonEulerJointR.hpp>
 
 /** \class FixedJointR
  *  \brief This class implements a fixed joint between one or two Newton/Euler Dynamical system
  *
  */
-class FixedJointR : public NewtonEulerR
+class FixedJointR : public NewtonEulerJointR
 {
 protected:
   /** serialization hooks
    */
   ACCEPT_SERIALIZATION(FixedJointR);
-  FixedJointR(): NewtonEulerR() {};
 
   /*Initial conditions*/
   double _G10G20d1x, _G10G20d1y, _G10G20d1z;
   double _cq2q101, _cq2q102, _cq2q103, _cq2q104;
 
 public:
+  /** Empty constructor. The relation may be initialized later by
+   * setInitialConditions. */
+  FixedJointR() : NewtonEulerJointR() {};
+
   /* constructor,
      \param a SP::NewtonEulerDS d1, a dynamical system containing the initial position
      \param a SP::NewtonEulerDS d2, a dynamical system containing the initial position
   */
-  FixedJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2);
-
-  /* constructor,
-     \param a SP::NewtonEulerDS d1, a dynamical system containing the initial position
-  */
-  FixedJointR(SP::NewtonEulerDS d1);
+  FixedJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2 = SP::NewtonEulerDS());
 
   /** destructor
    */
   virtual ~FixedJointR() {};
 
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2 = SP::SiconosVector());
+
   /** Get the number of constraints defined in the joint
       \return the number of constraints
    */
-  static unsigned int numberOfConstraints() { return 6; }
+  virtual unsigned int numberOfConstraints() { return 6; }
 
   virtual void computeJachq(double time, Interaction& inter, SP::BlockVector q0);
 
   virtual void computeh(double time, BlockVector& q0, SiconosVector& y);
+
+  virtual unsigned int numberOfDoF() { return 0; }
+
+  virtual DoF_Type typeOfDoF(unsigned int axis) { return DOF_TYPE_INVALID; }
 
 protected:
 

--- a/mechanics/src/joints/JointStopR.cpp
+++ b/mechanics/src/joints/JointStopR.cpp
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-/*! \file KneeJointR.cpp
+/*! \file JointStopR.cpp
 
 */
 

--- a/mechanics/src/joints/KneeJointR.hpp
+++ b/mechanics/src/joints/KneeJointR.hpp
@@ -34,7 +34,6 @@ protected:
   /** serialization hooks
    */
   ACCEPT_SERIALIZATION(KneeJointR);
-  KneeJointR(): NewtonEulerJointR() {};
 
   /** Coordinate of the knee point in the body frame of the first dynamical system _d1
    */
@@ -55,29 +54,39 @@ protected:
   double _G2P0x;
   double _G2P0y;
   double _G2P0z;
-  virtual void initComponents(Interaction& inter, VectorOfBlockVectors& DSlink, VectorOfVectors& workV, VectorOfSMatrices& workM);
+
+  virtual void initComponents(Interaction& inter, VectorOfBlockVectors& DSlink,
+                              VectorOfVectors& workV, VectorOfSMatrices& workM);
 
 public:
-  /* constructor,
-     \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-     \param a SP::NewtonEulerDS d2, a dynamical system containing the intial position
-     \param a SP::SiconosVector P, P contains the coordinates of the Knee point, in the frame of d1 where the origin is G1.
-                                  ie P contains the coordinates of the Knee point, in the object frame G1.
-  */
-  KneeJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::SiconosVector P);
 
-  /* constructor,
-     \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-     \param a SP::SiconosVector P, P contains the coordinates of the Knee point
-     \param bool indicating whether P is in the absolute frame (=true, default)
-            default) or the frame of the DS (=false)
-  */
-  KneeJointR(SP::NewtonEulerDS d1, SP::SiconosVector P, bool absoluteRef = true);
+  /** Empty constructor. The relation may be initialized later by
+   * setPoint, setAbsolute, and setInitialConditions. */
+  KneeJointR();
+
+  /** Constructor based on one or two dynamical systems and a point.
+   *  \param d1 first DynamicalSystem linked by the joint.
+   *  \param d2 second DynamicalSystem linked by the joint, or NULL
+   *            for absolute frame.
+   *  \param P SiconosVector of size 3 that defines the point around
+   *           which rotation is allowed.
+   *  \param absoluteRef if true, P is in the absolute frame,
+   *                     otherwise P is in d1 frame.
+   */
+  KneeJointR(SP::SiconosVector P, bool absoluteRef,
+             SP::NewtonEulerDS d1 = SP::NewtonEulerDS(),
+             SP::NewtonEulerDS d2 = SP::NewtonEulerDS());
 
   /** destructor
    */
-  void checkInitPos(SP::SiconosVector q1, SP::SiconosVector q2);
   virtual ~KneeJointR() {};
+
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2 = SP::SiconosVector());
+
+  /* Perform some checks on the initial conditions. */
+  void checkInitPos(SP::SiconosVector q1, SP::SiconosVector q2);
 
   /** Get the number of constraints defined in the joint
       \return the number of constraints

--- a/mechanics/src/joints/NewtonEulerJointR.hpp
+++ b/mechanics/src/joints/NewtonEulerJointR.hpp
@@ -34,14 +34,59 @@ protected:
   /** serialization hooks
    */
   ACCEPT_SERIALIZATION(NewtonEulerJointR);
-  NewtonEulerJointR(): NewtonEulerR(), _allowSelfCollide(false) {};
+  NewtonEulerJointR(): NewtonEulerR()
+                     , _allowSelfCollide(false)
+                     , _absoluteRef(true) {};
 
   /** A flag determining whether this joint should block
    * "self-collision", i.e., if true, bodies connected by this joint
    * will not enter into unilateral contact. */
   bool _allowSelfCollide;
 
+  /** Points used to defined the joint constraint. */
+  VectorOfVectors _points;
+
+  /** Axes used to defined the joint constraint. */
+  VectorOfVectors _axes;
+
+  /** Defines whether points and axes are specified in absolute or
+   * relative frame. */
+  bool _absoluteRef;
+
 public:
+
+  /** Set a point for this joint. The role of each point is specific
+   * to the joint subclass. Won't take effect until
+   * setInitialConditions is called.
+   *
+   * \param index The index of the points.
+   * \param point A SiconosVector of size 3.
+   */
+  void setPoint(unsigned int index, SP::SiconosVector point)
+    { _points[index] = point; }
+
+  /** Set an axis for this joint. The role of each axis is specific to
+   * the joint subclass. Won't take effect until setInitialConditions
+   * is called.
+   *
+   * \param index The index of the points.
+   * \param axis A SiconosVector of size 3.
+   */
+  void setAxis(unsigned int index, SP::SiconosVector axis)
+    { _axes[index] = axis; }
+
+  /** Set whether points and axes should be interpreted in absolute or
+   * relative frame. Won't take effect until setInitialConditions is
+   * called.
+   *
+   * \param absoluteRef true for absolute frame, false for relative frame.
+   */
+  void setAbsolute(bool absoluteRef)
+    { _absoluteRef = absoluteRef; }
+
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2=SP::SiconosVector()) = 0;
 
   /** Compute the vector of linear and angular positions of the free axes */
   virtual void computehDoF(double time, BlockVector& q0, SiconosVector& y,

--- a/mechanics/src/joints/PivotJointR.cpp
+++ b/mechanics/src/joints/PivotJointR.cpp
@@ -58,15 +58,36 @@ static double piwrap(double x)
   return fmod(x + 3*M_PI, 2*M_PI) - M_PI;
 }
 
-PivotJointR::PivotJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::SiconosVector P, SP::SiconosVector A): KneeJointR(d1, d2, P)
+PivotJointR::PivotJointR(SP::SiconosVector P, SP::SiconosVector A, bool absoluteRef,
+                         SP::NewtonEulerDS d1, SP::NewtonEulerDS d2)
+  : KneeJointR(P, absoluteRef, d1, d2)
+  , _A(std11::make_shared<SiconosVector>(3))
 {
-  _A.reset( new SiconosVector(*A) );
+  _axes.resize(1);
 
-  ::boost::math::quaternion<double> q1((*d1->q())(3), (*d1->q())(4),
-                                       (*d1->q())(5), (*d1->q())(6));
-  ::boost::math::quaternion<double> q2((*d2->q())(3), (*d2->q())(4),
-                                       (*d2->q())(5), (*d2->q())(6));
-  ::boost::math::quaternion<double> cq2q10(1.0 / q2 * q1);
+  setAxis(0, A);
+  if (d1)
+    setInitialConditions(d1->q(), d2 ? d2->q() : SP::SiconosVector());
+}
+
+static ::boost::math::quaternion<double> quat(const SP::SiconosVector& v)
+{
+  if (v && v->size()==7)
+    return ::boost::math::quaternion<double>((*v)(3),(*v)(4),(*v)(5),(*v)(6));
+  else if (v && v->size()==3)
+    return ::boost::math::quaternion<double>(0, (*v)(0),(*v)(1),(*v)(2));
+  else
+    return ::boost::math::quaternion<double>(1, 0, 0, 0);
+}
+
+void PivotJointR::setInitialConditions(SP::SiconosVector q1,
+                                       SP::SiconosVector q2)
+{
+  *_A = *_axes[0];
+
+  ::boost::math::quaternion<double> quat1(quat(q1));
+  ::boost::math::quaternion<double> quat2(quat(q2));
+  ::boost::math::quaternion<double> cq2q10(1.0 / quat2 * quat1);
 
   _cq2q101 = cq2q10.R_component_1();
   _cq2q102 = cq2q10.R_component_2();
@@ -76,9 +97,14 @@ PivotJointR::PivotJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::Siconos
   buildA1A2();
 
   double rot2to1w, rot2to1x, rot2to1y, rot2to1z;
-  rot2to1((*d1->q())(3), (*d1->q())(4), (*d1->q())(5), (*d1->q())(6),
-          (*d2->q())(3), (*d2->q())(4), (*d2->q())(5), (*d2->q())(6),
-          &rot2to1w, &rot2to1x, &rot2to1y, &rot2to1z);
+  if (q2)
+    rot2to1((*q1)(3), (*q1)(4), (*q1)(5), (*q1)(6),
+            (*q2)(3), (*q2)(4), (*q2)(5), (*q2)(6),
+            &rot2to1w, &rot2to1x, &rot2to1y, &rot2to1z);
+  else
+    rot2to1((*q1)(3), (*q1)(4), (*q1)(5), (*q1)(6),
+            1, 0, 0, 0,
+            &rot2to1w, &rot2to1x, &rot2to1y, &rot2to1z);
 
   _initial_AscalA1 = AscalA1(rot2to1x, rot2to1y, rot2to1z);
   _initial_AscalA2 = AscalA2(rot2to1x, rot2to1y, rot2to1z);
@@ -88,61 +114,11 @@ PivotJointR::PivotJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::Siconos
   // using atan2 so that stops can be placed correctly.
   double Adot2to1 = AscalA(rot2to1x, rot2to1y, rot2to1z);
   _initial_AscalA = 2*atan2(rot2to1w, Adot2to1);
+
   _twistCount = 0;
   _previousAngle = 0;
 }
 
-/* constructor,
-   \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-   \param a SP::SiconosVector P0, see KneeJointR documentation.
-   \param a SP::SiconosVector A, axis in the frame of the object.
-   \param a bool, used only by the KneeJointR constructor see KneeJointR documentation.
-*/
-PivotJointR::PivotJointR(SP::NewtonEulerDS d1, SP::SiconosVector P0, SP::SiconosVector A, bool absolutRef): KneeJointR(d1, P0, absolutRef)
-{
-  ::boost::math::quaternion<double> q1((*d1->q())(3), (*d1->q())(4),
-                                       (*d1->q())(5), (*d1->q())(6));
-  ::boost::math::quaternion<double> cq2q10(q1);
-
-  _cq2q101 = cq2q10.R_component_1();
-  _cq2q102 = cq2q10.R_component_2();
-  _cq2q103 = cq2q10.R_component_3();
-  _cq2q104 = cq2q10.R_component_4();
-
-  _A.reset( new SiconosVector(*A) );
-  buildA1A2();
-
-  double rot2to1w, rot2to1x, rot2to1y, rot2to1z;
-  rot2to1((*d1->q())(3), (*d1->q())(4), (*d1->q())(5), (*d1->q())(6),
-          1, 0, 0, 0, &rot2to1w, &rot2to1x, &rot2to1y, &rot2to1z);
-
-  _initial_AscalA1 = AscalA1(rot2to1x, rot2to1y, rot2to1z);
-  _initial_AscalA2 = AscalA2(rot2to1x, rot2to1y, rot2to1z);
-
-  // In case of joint constraints, it's okay to use dot product=0, but
-  // in the case of the free axis we must measure the actual angle
-  // using atan2 so that stops can be placed correctly.
-  double Adot2to1 = AscalA(rot2to1x, rot2to1y, rot2to1z);
-  _initial_AscalA = 2*atan2(rot2to1w, Adot2to1);
-  _twistCount = 0;
-  _previousAngle = 0;
-}
-
-void PivotJointR::initComponents(Interaction& inter, VectorOfBlockVectors& DSlink, VectorOfVectors& workV, VectorOfSMatrices& workM)
-{
-  KneeJointR::initComponents(inter,DSlink,workV,workM);
-  //if (_d2){
-  //proj_with_q  _jachqProj.reset(new SimpleMatrix(7,14));
-  //proj_with_q    _yProj.reset(new SiconosVector(7));
-  //_yProj.reset(new SiconosVector(5));
-  // }else{
-  //proj_with_q  _jachqProj.reset(new SimpleMatrix(6,7));
-  //proj_with_q    _yProj.reset(new SiconosVector(6));
-  //_yProj.reset(new SiconosVector(5));
-  // }
-  //proj_with_q  _jachqProj->zero();
-  //_yProj->zero();
-}
 void PivotJointR::buildA1A2()
 {
   double Ax = (*_A)(0);

--- a/mechanics/src/joints/PivotJointR.hpp
+++ b/mechanics/src/joints/PivotJointR.hpp
@@ -32,7 +32,6 @@ protected:
   /** serialization hooks
   */
   ACCEPT_SERIALIZATION(PivotJointR);
-  PivotJointR() : KneeJointR() {};
 
   /*Axis coordonates*/
   SP::SiconosVector _A;
@@ -59,8 +58,13 @@ protected:
                                SP::BlockVector q0, SimpleMatrix& jachq,
                                unsigned int axis);
 
-  virtual void Jd1d2(double X1, double Y1, double Z1, double q10, double q11, double q12, double q13, double X2, double Y2, double Z2, double q20, double q21, double q22, double q23);
-  virtual void Jd1(double X1, double Y1, double Z1, double q10, double q11, double q12, double q13);
+  virtual void Jd1d2(double X1, double Y1, double Z1,
+                     double q10, double q11, double q12, double q13,
+                     double X2, double Y2, double Z2,
+                     double q20, double q21, double q22, double q23);
+
+  virtual void Jd1(double X1, double Y1, double Z1,
+                   double q10, double q11, double q12, double q13);
 
   void rot2to1(double q10, double q11, double q12, double q13,
                double q20, double q21, double q22, double q23,
@@ -71,24 +75,28 @@ protected:
   double AscalA2(double q2to1x, double q2to1y, double q2to1z);
   double AscalA(double q2to1x, double q2to1y, double q2to1z);
 
-  virtual void initComponents(Interaction& inter, VectorOfBlockVectors& DSlink, VectorOfVectors& workV, VectorOfSMatrices& work);
-
 public:
-  /* constructor,
-     \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-     \param a SP::NewtonEulerDS d2, a dynamical system containing the intial position
-     \param a SP::SiconosVector P, see KneeJointR documentation.
-     \param a SP::SiconosVector A, Axis of the pivot in the frame of d1.
-  */
-  PivotJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::SiconosVector P, SP::SiconosVector A);
+  /** Empty constructor. The relation may be initialized later by
+   * setPoint, setAxis, setAbsolute, and setInitialConditions. */
+  PivotJointR() : KneeJointR() {};
 
-  /* constructor,
-     \param a SP::NewtonEulerDS d1, a dynamical system containing the intial position
-     \param a SP::SiconosVector P, see KneeJointR documentation.
-     \param a SP::SiconosVector A, axis in the frame of the object.
-     \param a bool, used only by the KneeJointR constructor see KneeJointR documentation.
-  */
-  PivotJointR(SP::NewtonEulerDS d1, SP::SiconosVector P, SP::SiconosVector A, bool absoluteRef = true);
+  /** Constructor based on one or two dynamical systems, a point and an axis.
+   *  \param d1 first DynamicalSystem linked by the joint.
+   *  \param d2 second DynamicalSystem linked by the joint, or NULL
+   *            for absolute frame.
+   *  \param P SiconosVector of size 3 that defines the point around
+   *           which rotation is allowed.
+   *  \param A SiconosVector of size 3 that defines the cylindrical axis.
+   *  \param absoluteRef if true, P and A are in the absolute frame,
+   *                     otherwise P and A are in d1 frame.
+   */
+  PivotJointR(SP::SiconosVector P, SP::SiconosVector A, bool absoluteRef,
+              SP::NewtonEulerDS d1 = SP::NewtonEulerDS(),
+              SP::NewtonEulerDS d2 = SP::NewtonEulerDS());
+
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2 = SP::SiconosVector());
 
   /** destructor
    */

--- a/mechanics/src/joints/PrismaticJointR.cpp
+++ b/mechanics/src/joints/PrismaticJointR.cpp
@@ -60,22 +60,18 @@
  * rot = lambda V,q: qmul(q, qmul(V, qinv(q)))
  */
 
-/**axe is the axis of the prismatic joint, in the frame of the first DS, d1.*/
-PrismaticJointR::PrismaticJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::SiconosVector axis)
+PrismaticJointR::PrismaticJointR(SP::SiconosVector axis, bool absoluteRef,
+                                 SP::NewtonEulerDS d1, SP::NewtonEulerDS d2)
   : NewtonEulerJointR()
+  , _axis0(std11::make_shared<SiconosVector>(3))
 {
-  _axis0 = axis;
-  computeFromInitialPosition(d1->q(), d2->q(), false);
+  _axes.resize(1);
+  setAbsolute(absoluteRef);
+  setAxis(0, axis);
+  if (d1)
+    setInitialConditions(d1->q(), d2 ? d2->q() : SP::SiconosVector());
 }
-/*axis is the axis of the prismatic joint, in the absolute frame.*/
-PrismaticJointR::PrismaticJointR(SP::NewtonEulerDS d1, SP::SiconosVector axis,
-                                 bool absoluteRef)
-  : NewtonEulerJointR()
-{
-  //    _d1=NULL;
-  _axis0 = axis;
-  computeFromInitialPosition(d1->q(), SP::SiconosVector(), absoluteRef);
-}
+
 void PrismaticJointR::displayInitialPosition()
 {
   std::cout << "Prismatic axis :\n";
@@ -87,10 +83,23 @@ void PrismaticJointR::displayInitialPosition()
             << " " << _cq2q103 << " " << _cq2q104 << "\n";
 }
 
-void PrismaticJointR::computeFromInitialPosition(SP::SiconosVector q1,
-                                                 SP::SiconosVector q2,
-                                                 bool absoluteRef)
+void PrismaticJointR::setInitialConditions(SP::SiconosVector q1,
+                                           SP::SiconosVector q2)
 {
+  *_axis0 = *_axes[0];
+
+  if (_absoluteRef)
+  {
+    // Adjust axis to be in q1 frame
+    boost::math::quaternion<double> quat1((*q1)(3), (*q1)(4), (*q1)(5), (*q1)(6));
+    boost::math::quaternion<double> quatA(0, _axis0->getValue(0),
+                                       _axis0->getValue(1), _axis0->getValue(2));
+    boost::math::quaternion<double> tmp = (1.0/quat1) * quatA * quat1;
+    _axis0->setValue(0, tmp.R_component_2());
+    _axis0->setValue(1, tmp.R_component_3());
+    _axis0->setValue(2, tmp.R_component_4());
+  }
+
   SP::SiconosVector q2i(new SiconosVector(7));
   q2i->zero();
   q2i->setValue(3, 1);
@@ -100,17 +109,6 @@ void PrismaticJointR::computeFromInitialPosition(SP::SiconosVector q1,
 
   ::boost::math::quaternion<double>    quat1(q1->getValue(3), q1->getValue(4), q1->getValue(5), q1->getValue(6));
   ::boost::math::quaternion<double>    quat2(q2i->getValue(3), q2i->getValue(4), q2i->getValue(5), q2i->getValue(6));
-
-  if (absoluteRef)
-  {
-    // Adjust axis to be in q1 frame
-    boost::math::quaternion<double> quatA(0, _axis0->getValue(0),
-                                          _axis0->getValue(1), _axis0->getValue(2));
-    boost::math::quaternion<double> tmp = 1.0/quat1 * quatA * quat1;
-    _axis0->setValue(0, tmp.R_component_2());
-    _axis0->setValue(1, tmp.R_component_3());
-    _axis0->setValue(2, tmp.R_component_4());
-  }
 
   computeV1V2FromAxis();
 

--- a/mechanics/src/joints/PrismaticJointR.hpp
+++ b/mechanics/src/joints/PrismaticJointR.hpp
@@ -42,7 +42,6 @@ protected:
   ACCEPT_SERIALIZATION(PrismaticJointR);
   PrismaticJointR(): NewtonEulerJointR() {};
 
-public:
   /** Axis of the prismatic point in the q1 inertial frame of reference
    */
   SP::SiconosVector _axis0;
@@ -79,26 +78,23 @@ public:
   double _cq2q103;
   double _cq2q104;
 
-  /** constructor from two dynamical systems and an axis
-   *  \param d1 first  DynamicalSystem link by the  joint
-   *  \param d2 second  DynamicalSystem link by the joint
-   * \param axis SiconosVector of size 3 that defines the prismatic axis
-   *  in the body  frame of d1 ?
+public:
+
+  /** Constructor based on one or two dynamical systems and an axis.
+   *  \param d1 first DynamicalSystem linked by the joint.
+   *  \param d2 second DynamicalSystem linked by the joint, or NULL
+   *            for absolute frame.
+   *  \param A SiconosVector of size 3 that defines the prismatic axis.
+   *  \param absoluteRef if true, A is in the absolute frame,
+   *                     otherwise A is in d1 frame.
    */
-  PrismaticJointR(SP::NewtonEulerDS d1, SP::NewtonEulerDS d2, SP::SiconosVector axis);
+  PrismaticJointR(SP::SiconosVector axis, bool absoluteRef,
+                  SP::NewtonEulerDS d1 = SP::NewtonEulerDS(),
+                  SP::NewtonEulerDS d2 = SP::NewtonEulerDS());
 
-
-  /** constructor from one dynamical systems and an axis
-   *  \param d1 the  DynamicalSystem link by the  joint
-   * \param axis SiconosVector of size 3 that defines the prismatic axis
-   *  in the inertial frame of reference
-   */
-  PrismaticJointR(SP::NewtonEulerDS d1, SP::SiconosVector axis,
-                  bool absoluteRef=false);
-
-  void computeFromInitialPosition(SP::SiconosVector q2,
-                                  SP::SiconosVector q1=SP::SiconosVector(),
-                                  bool absoluteRef=false);
+  /** Initialize the joint constants based on the provided initial positions. */
+  virtual void setInitialConditions(SP::SiconosVector q1,
+                                    SP::SiconosVector q2 = SP::SiconosVector());
 
   void displayInitialPosition();
 

--- a/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
+++ b/mechanics/src/mechanisms/MBTB/MBTB_PYTHON_API.cpp
@@ -398,20 +398,20 @@ void MBTB_JointBuild(unsigned int numJ,const std::string& JointName,
   sJointRelations[numJ]= new MBTB_JointR();
   if(jointType == PIVOT_1)
   {
-    sJointRelations[numJ]->_jointR.reset(new PivotJointR(sDS[ indexDS1],sDS[indexDS2],P,A));
+    sJointRelations[numJ]->_jointR.reset(new PivotJointR(P,A,false,sDS[ indexDS1],sDS[indexDS2]));
     sJointRelations[numJ]->_ds1 = sDS[indexDS1];
     //sAllDSByInter[numJ].insert(sDS[indexDS1]);
     //sAllDSByInter[numJ].insert(sDS[indexDS2]);
   }
   else if(jointType == PIVOT_0)
   {
-    sJointRelations[numJ]->_jointR.reset(new PivotJointR(sDS[indexDS1],P,A,false));
+    sJointRelations[numJ]->_jointR.reset(new PivotJointR(P,A,false,sDS[indexDS1]));
     sJointRelations[numJ]->_ds1 = sDS[indexDS1];
     // sAllDSByInter[numJ].insert(sDS[indexDS1]);
   }
   else if(jointType == PRISMATIC_0)
   {
-    sJointRelations[numJ]->_jointR.reset(new PrismaticJointR(sDS[indexDS1],A));
+    sJointRelations[numJ]->_jointR.reset(new PrismaticJointR(A,false,sDS[indexDS1]));
     sJointRelations[numJ]->_ds1 = sDS[indexDS1];
     // sAllDSByInter[numJ].insert(sDS[indexDS1]);
   }


### PR DESCRIPTION
I want to clean up the constructors for joints before the next release.  The main difficult point as mentioned in #161 is that some joints (Knee, Pivot..) default to absoluteRef=true while others (Prismatic) default to absoluteRef=false.  There are some other subtle differences, e.g. some joints initialize on `d1->q()` while others initialize on `d1->q0()`.  Also it is not always clear if the pointer to the provided vector will be retained, or if the data will be copied.

Thinking on this, I propose a few changes:
1. Separate joint "properties" (axis, points, absolute/relative..) from joint "initial conditions", i.e. position of DS.
2. Always force specifying absoluteRef, with no default.
3. However, allow joints to be created without specifying properties or initial conditions, or just by specifying properties and leaving initial conditions for later.
4. Retain the pointers to the provided SiconosVector, but only use it when the initial conditions are provided.  (i.e., not check for changes at every timestep..)

This patch makes the following changes:
1. Move handling of points and axes to two VectorOfVector objects in NewtonEulerJointR.
2. These VectorOfVectors are sized by the subclasses according to how many points and axes are needed.
3. A common interface setPoint() and setAxis() are provided in NewtonEulerJointR.
4. Calculation of initial conditions is done in a common function setInitialConditions(), which only takes SiconosVectors of size 7, no need to provide a NewtonEulerDS.  No longer have different constructors for the 1- and 2-DS conditions.
5. All constructors are reduced to calling setPoint/setAxis and setInitialConditions().
6. A default do-nothing constructor is publically available, the caller can call these functions him/herself.  The axis/point properties can be changed at any time but only take effect if setInitialConditions is called.
7. Order of arguments to the constructors is changed so that the 1-DS condition is just indicated by a default null pointer for second DS.

Some examples.

Construct a PivotJointR between a body and the absolute frame step by step:
~~~
SP::NewtonEulerDS body1, body2; // assume already exist..
SP::SiconosVector P(new SiconosVector(3));
SP::SiconosVector A(new SiconosVector(3));
PivotJointR joint();
joint.setPoint(0, P);
joint.setAxis(0, A);
joint.setAbsolute(true); // (this is default)
joint.setInitialConditions(body1->q());
~~~

Construct a PivotJointR between two bodies with a frame relative to body1:
~~~
PivotJointR joint(P, A, false);
joint.setInitialConditions(body1->q(), body2->q());
~~~

Construct a PivotJointR between two bodies with a frame relative to body1:
~~~
PivotJointR joint(P, A, false, body1, body2);
~~~

This patch contains changes to all JointsTests* examples to adapt the constructor call.