### PR TITLE
[kernel] make prepareIntegratorForDS require the Model.

### DIFF
--- a/Docs/sphinx/reference/modules/kernel/simulation.rst
+++ b/Docs/sphinx/reference/modules/kernel/simulation.rst
@@ -41,18 +41,12 @@ give the value of the :math:`\theta` parameter:
 
    osi = MoreauJeanOSI(0.5)
 
-Then, we attach the previously defined dynamical system to the integrator:
+Then, we attach the previously defined dynamical system to the integrator, which also adds the integrator to the simulation and prepares required work vectors:
 
 .. testcode::
 
-   bouncingBall.nonSmoothDynamicalSystem().setOSI(ball, osi)
+   simulation.prepareIntegratorForDS(osi, ball, bouncingBall, 0)
 
-And we attach this one step integrator to the simulation:
-
-.. testcode::
-
-   simulation.insertIntegrator(osi)
-   
 In the Moreau-Jean time-stepping scheme, the unilateral constraints, after
 being reformulated at the velocity level, lead at each timestep to nonsmooth
 optimization problems. In our case, it is a linear complementarity problem
@@ -130,8 +124,7 @@ attached to the integrator which is attached to the simulation:
 
 .. testcode::
 
-   diodesBridge.nonSmoothDynamicalSystem().setOSI(diodesBridge, osi)
-   simulation.insertIntegrator(osi)
+   simulation.prepareIntegratorForDS(osi, diodesBridge, DiodesBridgeModel, 0)
 
 At each time step, the Moreau-Jean time stepping scheme needs a linear
 complementarity problem to be solved. The `LCP` object is attached to

--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -83,7 +83,6 @@ void CommonSMC::initialize(const Model& m)
   _SMC.reset(new Model(t0, T));
   // Set up the simulation
   _simulationSMC.reset(new TimeStepping(_td));
-  _simulationSMC->setNonSmoothDynamicalSystemPtr(_SMC->nonSmoothDynamicalSystem());
 
   unsigned int sDim = _u->size();
   // create the interaction

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -118,7 +118,6 @@ void LinearSMCOT2::initialize(const Model& m)
   _PhiOSI.reset(new LsodarOSI());
   _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi);
   _simulPhi.reset(new EventDriven(_tdPhi, 0));
-  _simulPhi->setNonSmoothDynamicalSystemPtr(_modelPhi->nonSmoothDynamicalSystem());
   _simulPhi->prepareIntegratorForDS(_PhiOSI, _DSPhi, _modelPhi, _t0);
   _modelPhi->setSimulation(_simulPhi);
   _modelPhi->initialize();
@@ -127,7 +126,6 @@ void LinearSMCOT2::initialize(const Model& m)
   _PredOSI.reset(new LsodarOSI());
   _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred);
   _simulPred.reset(new EventDriven(_tdPred, 0));
-  _simulPred->setNonSmoothDynamicalSystemPtr(_modelPred->nonSmoothDynamicalSystem());
   _simulPred->prepareIntegratorForDS(_PredOSI, _DSPred, _modelPred, _t0);
   _modelPred->setSimulation(_simulPred);
   _modelPred->initialize();

--- a/control/src/Observer/LuenbergerObserver.cpp
+++ b/control/src/Observer/LuenbergerObserver.cpp
@@ -106,7 +106,6 @@ void LuenbergerObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _simulation->prepareIntegratorForDS(_integrator, _DS, _model, t0);
   _model->setSimulation(_simulation);
   _model->initialize();

--- a/control/src/Observer/SlidingReducedOrderObserver.cpp
+++ b/control/src/Observer/SlidingReducedOrderObserver.cpp
@@ -106,7 +106,6 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _simulation->prepareIntegratorForDS(_integrator, _DS, _model, t0);
   _model->setSimulation(_simulation);
   _model->initialize();

--- a/control/src/Simulation/ControlLsodarSimulation.cpp
+++ b/control/src/Simulation/ControlLsodarSimulation.cpp
@@ -46,9 +46,6 @@ ControlLsodarSimulation::ControlLsodarSimulation(double t0, double T, double h):
   std11::static_pointer_cast<LsodarOSI>(_processIntegrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlLinearAdditionalTermsED>(new ControlLinearAdditionalTermsED()));
 
-  _processSimulation->setNonSmoothDynamicalSystemPtr(
-    _model->nonSmoothDynamicalSystem());
-
   _DSG0 = _model->nonSmoothDynamicalSystem()->topology()->dSG(0);
   _IG0 = _model->nonSmoothDynamicalSystem()->topology()->indexSet0();
 

--- a/control/src/Simulation/ControlZOHSimulation.cpp
+++ b/control/src/Simulation/ControlZOHSimulation.cpp
@@ -42,9 +42,6 @@ ControlZOHSimulation::ControlZOHSimulation(double t0, double T, double h):
   _processSimulation->setName("plant simulation");
   _processSimulation->insertIntegrator(_processIntegrator);
 
-  _processSimulation->setNonSmoothDynamicalSystemPtr(
-    _model->nonSmoothDynamicalSystem());
-
   _DSG0 = _model->nonSmoothDynamicalSystem()->topology()->dSG(0);
   _IG0 = _model->nonSmoothDynamicalSystem()->topology()->indexSet0();
 

--- a/examples/Mechanics/BouncingBall/BouncingBallTS-CompliantContact.cpp
+++ b/examples/Mechanics/BouncingBall/BouncingBallTS-CompliantContact.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     // --- Simulation initialization ---
 
     cout << "====> Initialisation ..." << endl;
-    //bouncingBall->nonSmoothDynamicalSystem()->topology()->setOSI(ball, OSI);
+    s->prepareIntegratorForDS(OSI, ball, bouncingBall, t0)
     bouncingBall->initialize();
 
     // -- set the integrator for the ball --

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -266,11 +266,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -280,8 +277,9 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-    s->insertIntegrator(OSI2);
-    s->insertIntegrator(OSI3);
+    s->prepareIntegratorForDS(OSI1, beam1, myModel, t0);
+    s->prepareIntegratorForDS(OSI2, beam2, myModel, t0);
+    s->prepareIntegratorForDS(OSI3, beam3, myModel, t0);
     myModel->setSimulation(s);
 
     // =========================== End of model definition ===========================

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -297,11 +297,9 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
 
@@ -310,8 +308,10 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-    s->insertIntegrator(OSI2);
-    s->insertIntegrator(OSI3);
+    s->prepareIntegratorForDS(OSI1, beam1, myModel, t0);
+    s->prepareIntegratorForDS(OSI2, beam2, myModel, t0);
+    s->prepareIntegratorForDS(OSI3, beam3, myModel, t0);
+
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);
     myModel->setSimulation(s);

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
@@ -322,7 +322,6 @@ int main(int argc, char* argv[])
 
 
     SP::TimeSteppingCombinedProjection s(new TimeSteppingCombinedProjection(t, OSI, osnspb, osnspb_pos));
-    s->setNonSmoothDynamicalSystemPtr(myModel->nonSmoothDynamicalSystem());
     s->prepareIntegratorForDS(OSI, beam1, myModel, t0);
     s->prepareIntegratorForDS(OSI, beam2, myModel, t0);
     s->prepareIntegratorForDS(OSI, beam3, myModel, t0);

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -299,14 +299,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
-
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
-
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
-
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -316,9 +310,9 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-    s->insertIntegrator(OSI2);
-    s->insertIntegrator(OSI3);
-
+    s->prepareIntegratorForDS(OSI1, beam1, myModel, t0);
+    s->prepareIntegratorForDS(OSI2, beam2, myModel, t0);
+    s->prepareIntegratorForDS(OSI3, beam3, myModel, t0);
 
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -326,11 +326,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -340,9 +337,9 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-    s->insertIntegrator(OSI2);
-    s->insertIntegrator(OSI3);
-
+    s->prepareIntegratorForDS(OSI1, beam1, myModel, t0);
+    s->prepareIntegratorForDS(OSI2, beam2, myModel, t0);
+    s->prepareIntegratorForDS(OSI3, beam3, myModel, t0);
 
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
@@ -302,11 +302,8 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -317,8 +314,9 @@ int main(int argc, char* argv[])
 
     // -- (4) Simulation setup with (1) (2) (3)
     SP::TimeStepping s(new TimeStepping(t, OSI1, osnspb));
-    s->insertIntegrator(OSI2);
-    s->insertIntegrator(OSI3);
+    s->prepareIntegratorForDS(OSI1, beam1, myModel, t0);
+    s->prepareIntegratorForDS(OSI2, beam2, myModel, t0);
+    s->prepareIntegratorForDS(OSI3, beam3, myModel, t0);
 
     //    s->setComputeResiduY(true);
     //  s->setUseRelativeConvergenceCriteron(false);

--- a/examples/Mechanics/Music/guitar.py
+++ b/examples/Mechanics/Music/guitar.py
@@ -273,9 +273,8 @@ class Guitar(sk.Model):
         # (4) Simulation setup with (1) (2) (3)
         self.simu = sk.TimeStepping(t, default_integrator, osnspb)
         if integrators is not None:
-            self.simu.insertIntegrator(integrators[ds])
             for ds in integrators:
-                nsds.setOSI(ds, integrators[ds])
+                self.simu.prepareIntegratorForDS(integrators[ds], ds, self, t0)
         # simulation initialization
         self.setSimulation(self.simu)
         self.initialize()

--- a/io/src/test/KernelTest.cpp
+++ b/io/src/test/KernelTest.cpp
@@ -276,7 +276,6 @@ void KernelTest::t5()
 
   // -- (1) OneStepIntegrators --
   SP::MoreauJeanOSI OSI(new MoreauJeanOSI(theta));
-  bouncingBall->nonSmoothDynamicalSystem()->topology()->setOSI(ball, OSI);
 
   // -- (2) Time discretisation --
   SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
@@ -286,6 +285,7 @@ void KernelTest::t5()
 
   // -- (4) Simulation setup with (1) (2) (3)
   SP::TimeStepping s(new TimeStepping(t, OSI, osnspb));
+  s->prepareIntegratorForDS(OSI, ball, bouncingBall, t0);
 
   // =========================== End of model definition ===========================
 

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -78,7 +78,6 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const Model& m)
   _OSI.reset(new LsodarOSI());
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim.reset(new EventDriven(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_OSI, _DS, _model, m.t0());
   _model->setSimulation(_sim);
   _model->initialize();

--- a/kernel/src/simulationTools/Simulation.hpp
+++ b/kernel/src/simulationTools/Simulation.hpp
@@ -405,7 +405,7 @@ public:
    *  \param m The Model for initializing the OSI.
    *  \param time The current time for initializing the OSI. */
   void prepareIntegratorForDS(SP::OneStepIntegrator osi, SP::DynamicalSystem ds,
-                              SP::Model m=SP::Model(), double time=0);
+                              SP::Model m, double time);
 
   /** Set an object to automatically manage interactions during the simulation */
   void insertInteractionManager(SP::InteractionManager manager)

--- a/kernel/src/simulationTools/test/OSNSPTest.cpp
+++ b/kernel/src/simulationTools/test/OSNSPTest.cpp
@@ -40,7 +40,6 @@ void OSNSPTest::init()
   _osi.reset(new EulerMoreauOSI(_theta));
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim.reset(new TimeStepping(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_osi, _DS, _model, _t0);
   _model->setSimulation(_sim);
   _model->initialize();
@@ -91,7 +90,6 @@ void OSNSPTest::testAVI()
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _sim.reset(new TimeStepping(_TD));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_osi, _DS, _model, _t0);
   SP::AVI osnspb(new AVI());
   _sim->insertNonSmoothProblem(osnspb);

--- a/kernel/src/simulationTools/test/ZOHTest.cpp
+++ b/kernel/src/simulationTools/test/ZOHTest.cpp
@@ -38,7 +38,6 @@ void ZOHTest::init()
   _TD.reset(new TimeDiscretisation(_t0, _h));
   _model.reset(new Model(_t0, _T));
   _sim.reset(new TimeStepping(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _ZOH.reset(new ZeroOrderHoldOSI());
   _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
   _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
@@ -162,7 +161,6 @@ void ZOHTest::testMatrixIntegration2()
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
@@ -230,7 +228,6 @@ void ZOHTest::testMatrixIntegration3()
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
@@ -304,7 +301,6 @@ void ZOHTest::testMatrixIntegration4()
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);

--- a/kernel/swig/tests/test_lagrangiands_osi.py
+++ b/kernel/swig/tests/test_lagrangiands_osi.py
@@ -92,7 +92,6 @@ def test_lagrangian_and_osis():
     # -- (4) Simulation setup with (1) (2) (3)
     simu = sk.TimeStepping(td, standard, lcp)
     # extra osi must be explicitely inserted into simu and linked to ds
-    simu.setNonSmoothDynamicalSystemPtr(model.nonSmoothDynamicalSystem())
     simu.prepareIntegratorForDS(bilbao, ds_list['LLDDS+MJB'], model, tinit)
     simu.prepareIntegratorForDS(bilbao, ds_list['LLDDS+MJB2'], model, tinit)
 


### PR DESCRIPTION
Makes Simulation::setNonSmoothDynamicalSystemPtr() and explicit calls
to setOSI() unnecessary.

Attempt to stabilise the API for DS/OSI link initialiation, per issue #142, comments welcome.