### PR TITLE
[kernel] move Simulation::prepareIntegratorForDS to NSDS::setOSI taking Model param

### DIFF
--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -83,7 +83,6 @@ void CommonSMC::initialize(const Model& m)
   _SMC.reset(new Model(t0, T));
   // Set up the simulation
   _simulationSMC.reset(new TimeStepping(_td));
-  _simulationSMC->setNonSmoothDynamicalSystemPtr(_SMC->nonSmoothDynamicalSystem());
 
   unsigned int sDim = _u->size();
   // create the interaction
@@ -156,13 +155,14 @@ void CommonSMC::initialize(const Model& m)
     _integratorSMC.reset(new ZeroOrderHoldOSI());
   }
 
-  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC);
+  _SMC->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS_SMC, _integratorSMC,
+                                                          _SMC, t0);
   _SMC->nonSmoothDynamicalSystem()->setName(_DS_SMC, "plant_SMC");
   _SMC->nonSmoothDynamicalSystem()->link(_interactionSMC, _DS_SMC);
   _SMC->nonSmoothDynamicalSystem()->setControlProperty(_interactionSMC, true);
   _SMC->nonSmoothDynamicalSystem()->topology()->setName(_interactionSMC, "Sgn_SMC");
   _simulationSMC->setName("linear sliding mode controller simulation");
-  _simulationSMC->prepareIntegratorForDS(_integratorSMC, _DS_SMC, _SMC, t0);
+  _simulationSMC->insertIntegrator(_integratorSMC);
   // OneStepNsProblem
   _OSNSPB_SMC->numericsSolverOptions()->dparam[0] = _precision;
   //    std::cout << _OSNSPB_SMC->numericsSolverOptions()->dparam[0] <<std::endl;

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -116,19 +116,19 @@ void LinearSMCOT2::initialize(const Model& m)
 
   _modelPhi.reset(new Model(_t0, _T));
   _PhiOSI.reset(new LsodarOSI());
-  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi);
+  _modelPhi->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPhi, _PhiOSI,
+                                                               _modelPhi, _t0);
   _simulPhi.reset(new EventDriven(_tdPhi, 0));
-  _simulPhi->setNonSmoothDynamicalSystemPtr(_modelPhi->nonSmoothDynamicalSystem());
-  _simulPhi->prepareIntegratorForDS(_PhiOSI, _DSPhi, _modelPhi, _t0);
+  _simulPhi->insertIntegrator(_PhiOSI);
   _modelPhi->setSimulation(_simulPhi);
   _modelPhi->initialize();
   // Integration for Gamma
   _modelPred.reset(new Model(_t0, _T));
   _PredOSI.reset(new LsodarOSI());
-  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred);
+  _modelPred->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DSPred, _PredOSI,
+                                                                _modelPred, _t0);
   _simulPred.reset(new EventDriven(_tdPred, 0));
-  _simulPred->setNonSmoothDynamicalSystemPtr(_modelPred->nonSmoothDynamicalSystem());
-  _simulPred->prepareIntegratorForDS(_PredOSI, _DSPred, _modelPred, _t0);
+  _simulPred->insertIntegrator(_PredOSI);
   _modelPred->setSimulation(_simulPred);
   _modelPred->initialize();
 

--- a/control/src/Observer/LuenbergerObserver.cpp
+++ b/control/src/Observer/LuenbergerObserver.cpp
@@ -87,7 +87,8 @@ void LuenbergerObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _integrator,
+                                                            _model, t0);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);
@@ -106,8 +107,7 @@ void LuenbergerObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _simulation->prepareIntegratorForDS(_integrator, _DS, _model, t0);
+  _simulation->insertIntegrator(_integrator);
   _model->setSimulation(_simulation);
   _model->initialize();
 

--- a/control/src/Observer/SlidingReducedOrderObserver.cpp
+++ b/control/src/Observer/SlidingReducedOrderObserver.cpp
@@ -87,7 +87,8 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
   _integrator.reset(new ZeroOrderHoldOSI());
   std11::static_pointer_cast<ZeroOrderHoldOSI>(_integrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlZOHAdditionalTerms>(new ControlZOHAdditionalTerms()));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _integrator,
+                                                            _model, t0);
 
   // Add the necessary properties
   DynamicalSystemsGraph& DSG0 = *_model->nonSmoothDynamicalSystem()->topology()->dSG(0);
@@ -106,8 +107,7 @@ void SlidingReducedOrderObserver::initialize(const Model& m)
 
   // all necessary things for simulation
   _simulation.reset(new TimeStepping(_td, 0));
-  _simulation->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _simulation->prepareIntegratorForDS(_integrator, _DS, _model, t0);
+  _simulation->insertIntegrator(_integrator);
   _model->setSimulation(_simulation);
   _model->initialize();
 

--- a/control/src/Simulation/ControlLsodarSimulation.cpp
+++ b/control/src/Simulation/ControlLsodarSimulation.cpp
@@ -46,9 +46,6 @@ ControlLsodarSimulation::ControlLsodarSimulation(double t0, double T, double h):
   std11::static_pointer_cast<LsodarOSI>(_processIntegrator)->setExtraAdditionalTerms(
       std11::shared_ptr<ControlLinearAdditionalTermsED>(new ControlLinearAdditionalTermsED()));
 
-  _processSimulation->setNonSmoothDynamicalSystemPtr(
-    _model->nonSmoothDynamicalSystem());
-
   _DSG0 = _model->nonSmoothDynamicalSystem()->topology()->dSG(0);
   _IG0 = _model->nonSmoothDynamicalSystem()->topology()->indexSet0();
 

--- a/control/src/Simulation/ControlSimulation.cpp
+++ b/control/src/Simulation/ControlSimulation.cpp
@@ -93,10 +93,8 @@ void ControlSimulation::setTheta(unsigned int newTheta)
 
 void ControlSimulation::addDynamicalSystem(SP::DynamicalSystem ds, const std::string& name)
 {
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
-
-  _processSimulation->prepareIntegratorForDS(_processIntegrator, ds, _model,
-                                             _processSimulation->nextTime());
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(
+    ds, _processIntegrator, _model, _processSimulation->nextTime());
 
   if (!name.empty())
   {

--- a/control/src/Simulation/ControlZOHSimulation.cpp
+++ b/control/src/Simulation/ControlZOHSimulation.cpp
@@ -42,9 +42,6 @@ ControlZOHSimulation::ControlZOHSimulation(double t0, double T, double h):
   _processSimulation->setName("plant simulation");
   _processSimulation->insertIntegrator(_processIntegrator);
 
-  _processSimulation->setNonSmoothDynamicalSystemPtr(
-    _model->nonSmoothDynamicalSystem());
-
   _DSG0 = _model->nonSmoothDynamicalSystem()->topology()->dSG(0);
   _IG0 = _model->nonSmoothDynamicalSystem()->topology()->indexSet0();
 

--- a/control/swig/tests/test_smc.py
+++ b/control/swig/tests/test_smc.py
@@ -58,11 +58,10 @@ def test_smc1():
     # Creation of the Simulation
     processSimulation = TimeStepping(processTD, 0)
     processSimulation.setName("plant simulation")
-    processSimulation.setNonSmoothDynamicalSystemPtr(
-        process.nonSmoothDynamicalSystem())
     # Declaration of the integrator
     processIntegrator = ZeroOrderHoldOSI()
-    processSimulation.prepareIntegratorForDS(processIntegrator, processDS, process, t0)
+    process.nonSmoothDynamicalSystem().setOSI(processDS, processIntegrator, process, t0)
+    processSimulation.insertIntegrator(processIntegrator)
     # Actuator, Sensor & ControlManager
     control = ControlManager(processSimulation)
     sens = LinearSensor(processDS, sensorC, sensorD)

--- a/examples/Electronics/IdealSwitch/src/myDS.cpp
+++ b/examples/Electronics/IdealSwitch/src/myDS.cpp
@@ -41,10 +41,9 @@ void MyDS::computeJacobianfx(double t, bool  b)
   _jacobianfx->setValue(0, 0, 0);
 }
 
-void MyDS::computeJacobianfx(double t, const SiconosVector& v)
+void MyDS::computeJacobianfx(double t, SP::SiconosVector v)
 {
   _jacobianfx->setValue(0, 0, 0);
-
 }
 
 void MyDS::computeRhs(double t, bool  b)

--- a/examples/Electronics/IdealSwitch/src/myDS.h
+++ b/examples/Electronics/IdealSwitch/src/myDS.h
@@ -112,7 +112,7 @@ public:
    *  \param double time : current time
    *  \param SP::SiconosVector
    */
-  virtual void computeJacobianfx(double, const SiconosVector&);
+  virtual void computeJacobianfx(double, SP::SiconosVector);
 
   /** Default function to the right-hand side term
    *  \param double time : current time

--- a/examples/Mechanics/BulletBouncingBox/BulletBouncingBoxDynamic.cpp
+++ b/examples/Mechanics/BulletBouncingBox/BulletBouncingBoxDynamic.cpp
@@ -103,7 +103,7 @@ int main()
     SP::BodyDS body(makeBox(g, position_init, velocity_init));
 
     // -- Add the dynamical system in the non smooth dynamical system
-    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
+    model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, osi, model, t0);
 
     SP::SiconosPlane ground(std11::make_shared<SiconosPlane>());
 
@@ -219,8 +219,8 @@ int main()
       if (k==100)
       {
         SP::BodyDS ds(makeBox(g, 3.0, 0));
-        simulation->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
-        simulation->prepareIntegratorForDS(osi, ds, model, simulation->nextTime());
+        model->nonSmoothDynamicalSystem()->insertDynamicalSystem(
+          ds, osi, model, simulation->nextTime());
       }
 
       collision_manager->resetStatistics();

--- a/examples/Mechanics/Disks/src/BodiesViewer.hpp
+++ b/examples/Mechanics/Disks/src/BodiesViewer.hpp
@@ -127,7 +127,7 @@ struct ForMassValue : public Question<double>
   ANSWER(Disk, mass()->getValue(0, 0));
   ANSWER(Circle, mass()->getValue(0, 0));
   ANSWER(SphereLDS, mass()->getValue(0, 0));
-  ANSWER(SphereNEDS, massValue());
+  ANSWER(SphereNEDS, scalarMass());
   IFBULLET(ANSWER(BulletDS, massValue()));
 };
 

--- a/examples/Mechanics/Disks/src/Disks.cpp
+++ b/examples/Mechanics/Disks/src/Disks.cpp
@@ -209,11 +209,9 @@ void Disks::init()
       FExt->setValue(1, -m * g);
       body->setFExtPtr(FExt);
 
-      // add the dynamical system to the one step integrator
-      osi->insertDynamicalSystem(body);
-
       // add the dynamical system in the non smooth dynamical system
-      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
+      // and associate it with the integrator
+      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, osi, _model, t0);
 
     }
 

--- a/examples/Mechanics/Disks/src/DisksViewer.cpp
+++ b/examples/Mechanics/Disks/src/DisksViewer.cpp
@@ -61,7 +61,6 @@ void DisksViewer::draw()
 
   float lbdmax = 0.;
 
-  DSIterator itDS;
   SP::InteractionsGraph I1;
   SP::Interaction interaction;
   SP::Relation relation;

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -266,11 +266,11 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam1, OSI1, *myModel, t0);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam2, OSI2, *myModel, t0);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam3, OSI3, *myModel, t0);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -297,11 +297,11 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam1, OSI1, *myModel, t0);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam2, OSI2, *myModel, t0);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam3, OSI3, *myModel, t0);
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));
 

--- a/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
+++ b/examples/Mechanics/JointsTests/NE_3DS_3Knee_1Prism_MLCP_MoreauJeanCombinedProjection.cpp
@@ -323,9 +323,6 @@ int main(int argc, char* argv[])
 
     SP::TimeSteppingCombinedProjection s(new TimeSteppingCombinedProjection(t, OSI, osnspb, osnspb_pos));
     s->setNonSmoothDynamicalSystemPtr(myModel->nonSmoothDynamicalSystem());
-    s->prepareIntegratorForDS(OSI, beam1, myModel, t0);
-    s->prepareIntegratorForDS(OSI, beam2, myModel, t0);
-    s->prepareIntegratorForDS(OSI, beam3, myModel, t0);
     s->setProjectionMaxIteration(1000);
     s->setConstraintTol(1e-08);
     s->setConstraintTolUnilateral(1e-08);

--- a/examples/Mechanics/JointsTests/NE_BouncingBeam.cpp
+++ b/examples/Mechanics/JointsTests/NE_BouncingBeam.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
     SP::SiconosVector axe1(new SiconosVector(3));
     axe1->zero();
     axe1->setValue(2, 1);
-    SP::PrismaticJointR relation4(new PrismaticJointR(bouncingbeam, axe1));
+    SP::PrismaticJointR relation4(new PrismaticJointR(axe1, false, bouncingbeam));
     SP::NonSmoothLaw nslaw4(new EqualityConditionNSL(relation4->numberOfConstraints()));
 
     SP::Interaction inter4(new Interaction(nslaw4, relation4));

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_GMP.cpp
@@ -299,13 +299,13 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam1, OSI1, *myModel, t0);
 
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam2, OSI2, *myModel, t0);
 
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam3, OSI3, *myModel, t0);
 
 
     // -- (2) Time discretisation --

--- a/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
+++ b/examples/Mechanics/JointsTestsWithBoundaryConditions/NE_3DS_3Knee_1Prism_MLCP.cpp
@@ -326,11 +326,11 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam1, OSI1, *myModel, t0);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam2, OSI2, *myModel, t0);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam3, OSI3, *myModel, t0);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));

--- a/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
+++ b/examples/Mechanics/JointsTestsWithInternalForces/NE_3DS_3Knee_1Prism_MLCP_withSprings.cpp
@@ -302,11 +302,11 @@ int main(int argc, char* argv[])
 
     // -- (1) OneStepIntegrators --
     SP::MoreauJeanOSI OSI1(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam1,OSI1);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam1, OSI1, *myModel, t0);
     SP::MoreauJeanOSI OSI2(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam2,OSI2);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam2, OSI2, *myModel, t0);
     SP::MoreauJeanOSI OSI3(new MoreauJeanOSI(theta));
-    myModel->nonSmoothDynamicalSystem()->topology()->setOSI(beam3,OSI3);
+    myModel->nonSmoothDynamicalSystem()->setOSI(beam3, OSI3, *myModel, t0);
 
     // -- (2) Time discretisation --
     SP::TimeDiscretisation t(new TimeDiscretisation(t0, h));

--- a/examples/Mechanics/Spheres/Lagrangian/src/Spheres.cpp
+++ b/examples/Mechanics/Spheres/Lagrangian/src/Spheres.cpp
@@ -131,11 +131,9 @@ void Spheres::init()
       FExt->setValue(2, -m * g);
       body->setFExtPtr(FExt);
 
-      // add the dynamical system to the one step integrator
-      osi->insertDynamicalSystem(body);
-
       // add the dynamical system in the non smooth dynamical system
-      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
+      // and link it to the OSI
+      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, osi, _model, t0);
 
     }
 

--- a/examples/Mechanics/Spheres/NewtonEuler/src/Spheres.cpp
+++ b/examples/Mechanics/Spheres/NewtonEuler/src/Spheres.cpp
@@ -136,7 +136,9 @@ void Spheres::init()
       body->setFExtPtr(FExt);
 
       // add the dynamical system in the non smooth dynamical system
-      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body);
+      // and link it to the OSI
+      _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(body, osi, _model, t0);
+
     }
 
     // ------------------

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1231,11 +1231,8 @@ class Hdf5():
                 if birth:
                     nsds = self._model.nonSmoothDynamicalSystem()
                     if use_proposed:
-                        nsds.insertDynamicalSystem(body)
-                        self._model.simulation().prepareIntegratorForDS(
-                            self._osi, body, self._model,
-                            self._model.simulation().nextTime())
-                        self._model.simulation().initialize(self._model, False)
+                        nsds.insertDynamicalSystem(body, self._osi, self._model,
+                                                   self._model.simulation().nextTime())
                     elif use_original:
                         self._broadphase.addDynamicObject(
                             body,
@@ -1244,7 +1241,8 @@ class Hdf5():
                     nsds.setName(body, str(name))
                 else:
                     nsds = self._model.nonSmoothDynamicalSystem()
-                    nsds.insertDynamicalSystem(body)
+                    nsds.insertDynamicalSystem(body, self._osi, self._model,
+                                               self._model.simulation().nextTime())
                     nsds.setName(body, str(name))
 
     def importJoint(self, name):

--- a/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
+++ b/kernel/src/modelingTools/NonSmoothDynamicalSystem.hpp
@@ -109,13 +109,24 @@ public:
   }
 
   /** add a dynamical system into the DS graph (as a vertex)
-   * \param ds a pointer to the system to add
+   * \param ds a pointer to the system to add.
+   * \param osi Optionally specify an OSI to associate with the DS.
+   * \param time If osi is specified, time should be specified as well.
    */
-  inline void insertDynamicalSystem(SP::DynamicalSystem ds)
-  {
-    _topology->insertDynamicalSystem(ds);
-    _mIsLinear = ((ds)->isLinear() && _mIsLinear);
-  };
+  void insertDynamicalSystem(SP::DynamicalSystem ds,
+                             SP::OneStepIntegrator osi = SP::OneStepIntegrator(),
+                             SP::Model model = SP::Model(),
+                             double time = -1.0);
+
+  /** set and initialize the OSI to be used to integrate a DS
+   * \param ds The DS to link to an OSI.
+   * \param osi The OSI to link to a DS.
+   * \param time The time to use for initializing the DS work vectors
+   *             for the OSI, usually either t0 of the Model, or the
+   *             current Simulation time.
+   */
+  void setOSI(SP::DynamicalSystem ds, SP::OneStepIntegrator osi,
+              Model& model, double time);
 
   /** get Dynamical system number I
    * \param nb the identifier of the DynamicalSystem to get

--- a/kernel/src/simulationTools/D1MinusLinearOSI.cpp
+++ b/kernel/src/simulationTools/D1MinusLinearOSI.cpp
@@ -112,7 +112,8 @@ unsigned int D1MinusLinearOSI::numberOfIndexSets() const
   RuntimeException::selfThrow("D1MinusLinearOSI::numberOfIndexSet - not implemented for D1minusLinear of type: " + _typeOfD1MinusLinearOSI);
   return 0;
 }
-void D1MinusLinearOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void D1MinusLinearOSI::initializeDynamicalSystem(const Model& m, double t,
+                                                 SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);

--- a/kernel/src/simulationTools/D1MinusLinearOSI.hpp
+++ b/kernel/src/simulationTools/D1MinusLinearOSI.hpp
@@ -216,7 +216,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/EulerMoreauOSI.cpp
+++ b/kernel/src/simulationTools/EulerMoreauOSI.cpp
@@ -93,7 +93,8 @@ SP::SiconosMatrix EulerMoreauOSI::WBoundaryConditions(SP::DynamicalSystem ds)
   return _dynamicalSystemsGraph->properties(_dynamicalSystemsGraph->descriptor(ds)).WBoundaryConditions;
 }
 
-void EulerMoreauOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void EulerMoreauOSI::initializeDynamicalSystem(const Model& m, double t,
+                                               SP::DynamicalSystem ds)
 {
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);
 

--- a/kernel/src/simulationTools/EulerMoreauOSI.hpp
+++ b/kernel/src/simulationTools/EulerMoreauOSI.hpp
@@ -281,7 +281,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/Hem5OSI.cpp
+++ b/kernel/src/simulationTools/Hem5OSI.cpp
@@ -479,7 +479,8 @@ void Hem5OSI::fprob(integer* IFCN,
 // {
 //   std11::static_pointer_cast<EventDriven>(_simulation)->computeJacobianfx(shared_from_this(), sizeOfX, time, x, jacob);
 // }
-void Hem5OSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void Hem5OSI::initializeDynamicalSystem(const Model& m, double t,
+                                        SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);
@@ -587,7 +588,7 @@ void Hem5OSI::fillDSLinks(Interaction &inter,
 }
 
 
-void Hem5OSI::initialize(Model& m)
+void Hem5OSI::initialize(const Model& m)
 {
 
   DEBUG_PRINT("Hem5OSI::initialize(Model& m)\n");

--- a/kernel/src/simulationTools/Hem5OSI.hpp
+++ b/kernel/src/simulationTools/Hem5OSI.hpp
@@ -251,14 +251,15 @@ public:
 
   /** initialization of the integrator
    */
-  void initialize(Model& m);
+  void initialize(const Model& m);
+
   /** initialization of the work vectors and matrices (properties) related to
    *  one dynamical system on the graph and needed by the osi
    * \param m the Model
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/LsodarOSI.cpp
+++ b/kernel/src/simulationTools/LsodarOSI.cpp
@@ -235,7 +235,8 @@ void LsodarOSI::jacobianfx(integer* sizeOfX, doublereal* time, doublereal* x, in
 }
 
 
-void LsodarOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void LsodarOSI::initializeDynamicalSystem(const Model& m, double t,
+                                          SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("LsodarOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n");
   // Get work buffers from the graph
@@ -353,7 +354,7 @@ void LsodarOSI::fillDSLinks(Interaction &inter,
   }
 }
 
-void LsodarOSI::initialize(Model& m)
+void LsodarOSI::initialize(const Model& m)
 {
   DEBUG_BEGIN("LsodarOSI::initialize(Model& m)\n");
   _xWork.reset(new BlockVector());

--- a/kernel/src/simulationTools/LsodarOSI.hpp
+++ b/kernel/src/simulationTools/LsodarOSI.hpp
@@ -245,7 +245,7 @@ public:
 
   /** initialization of the integrator
    */
-  void initialize(Model& m);
+  void initialize(const Model& m);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one dynamical system on the graph and needed by the osi
@@ -253,7 +253,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -76,10 +76,9 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const Model& m)
   // integration stuff
   _model.reset(new Model(m.t0(), m.finalT()));
   _OSI.reset(new LsodarOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _OSI, _model, m.t0());
   _sim.reset(new EventDriven(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_OSI, _DS, _model, m.t0());
+  _sim->insertIntegrator(_OSI);
   _model->setSimulation(_sim);
   _model->initialize();
 

--- a/kernel/src/simulationTools/MoreauJeanBilbaoOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanBilbaoOSI.cpp
@@ -39,7 +39,8 @@ MoreauJeanBilbaoOSI::MoreauJeanBilbaoOSI():
   _steps=1;
 }
 
-void MoreauJeanBilbaoOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void MoreauJeanBilbaoOSI::initializeDynamicalSystem(const Model& m, double t,
+                                                    SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
   // const DynamicalSystemsGraph::VDescriptor& dsv = _dynamicalSystemsGraph->descriptor(ds);

--- a/kernel/src/simulationTools/MoreauJeanBilbaoOSI.hpp
+++ b/kernel/src/simulationTools/MoreauJeanBilbaoOSI.hpp
@@ -53,7 +53,8 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  virtual void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  virtual void initializeDynamicalSystem(const Model& m, double t,
+                                         SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/MoreauJeanCombinedProjectionOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanCombinedProjectionOSI.cpp
@@ -43,7 +43,9 @@ MoreauJeanCombinedProjectionOSI::MoreauJeanCombinedProjectionOSI(double theta) :
 }
 
 
-void MoreauJeanCombinedProjectionOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void MoreauJeanCombinedProjectionOSI::initializeDynamicalSystem(const Model& m,
+                                                                double t,
+                                                                SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("MoreauJeanCombinedProjectionOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds) \n");
  

--- a/kernel/src/simulationTools/MoreauJeanCombinedProjectionOSI.hpp
+++ b/kernel/src/simulationTools/MoreauJeanCombinedProjectionOSI.hpp
@@ -80,7 +80,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/MoreauJeanDirectProjectionOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanDirectProjectionOSI.cpp
@@ -73,7 +73,9 @@ MoreauJeanDirectProjectionOSI::MoreauJeanDirectProjectionOSI(double theta, doubl
   _activateYVelThreshold =   SICONOS_MPC_DEFAULT_ACTIVATION_VEL_THRESHOLD;
 }
 
-void MoreauJeanDirectProjectionOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void MoreauJeanDirectProjectionOSI::initializeDynamicalSystem(const Model& m,
+                                                              double t,
+                                                              SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("MoreauJeanDirectProjectionOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds) \n");
   MoreauJeanOSI::initializeDynamicalSystem(m, t, ds);

--- a/kernel/src/simulationTools/MoreauJeanDirectProjectionOSI.hpp
+++ b/kernel/src/simulationTools/MoreauJeanDirectProjectionOSI.hpp
@@ -135,7 +135,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/MoreauJeanGOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanGOSI.cpp
@@ -64,7 +64,8 @@ MoreauJeanGOSI::MoreauJeanGOSI(double theta, double gamma):
     _useGamma = false;
   }
 }
-void MoreauJeanGOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void MoreauJeanGOSI::initializeDynamicalSystem(const Model& m, double t,
+                                               SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);

--- a/kernel/src/simulationTools/MoreauJeanGOSI.hpp
+++ b/kernel/src/simulationTools/MoreauJeanGOSI.hpp
@@ -306,7 +306,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/MoreauJeanOSI.cpp
+++ b/kernel/src/simulationTools/MoreauJeanOSI.cpp
@@ -102,7 +102,8 @@ SP::SiconosMatrix MoreauJeanOSI::WBoundaryConditions(SP::DynamicalSystem ds)
 }
 
 
-void MoreauJeanOSI::initializeDynamicalSystem(Model&, double t, SP::DynamicalSystem ds)
+void MoreauJeanOSI::initializeDynamicalSystem(const Model&, double t,
+                                              SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("MoreauJeanOSI::initializeDynamicalSystem(Model&, double t, SP::DynamicalSystem ds)\n");
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);

--- a/kernel/src/simulationTools/MoreauJeanOSI.hpp
+++ b/kernel/src/simulationTools/MoreauJeanOSI.hpp
@@ -295,7 +295,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system   
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to 
    *  one interaction on the graph and needed by the osi 

--- a/kernel/src/simulationTools/NewMarkAlphaOSI.cpp
+++ b/kernel/src/simulationTools/NewMarkAlphaOSI.cpp
@@ -404,7 +404,8 @@ void NewMarkAlphaOSI::computeFreeOutput(InteractionsGraph::VDescriptor& vertex_i
   DEBUG_END("NewMarkAlphaOSI::computeFreeOutput(InteractionsGraph::VDescriptor& vertex_inter, OneStepNSProblem* osnsp)\n");
 }
 
-void NewMarkAlphaOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void NewMarkAlphaOSI::initializeDynamicalSystem(const Model& m, double t,
+                                                SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("NewMarkAlphaOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n")
 

--- a/kernel/src/simulationTools/NewMarkAlphaOSI.hpp
+++ b/kernel/src/simulationTools/NewMarkAlphaOSI.hpp
@@ -234,7 +234,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/OneStepIntegrator.cpp
+++ b/kernel/src/simulationTools/OneStepIntegrator.cpp
@@ -54,7 +54,7 @@ OneStepIntegrator::_initializeDSWorkVectors(SP::DynamicalSystem ds)
   return wv;
 }
 
-void OneStepIntegrator::initialize( Model& m )
+void OneStepIntegrator::initialize( const Model& m )
 {
   if (_extraAdditionalTerms)
   {

--- a/kernel/src/simulationTools/OneStepIntegrator.hpp
+++ b/kernel/src/simulationTools/OneStepIntegrator.hpp
@@ -238,7 +238,7 @@ public:
   /** initialise the integrator
    * \param m a Model
    */
-  virtual void initialize(Model& m );
+  virtual void initialize(const Model& m);
 
   /** Initialization process of the nonsmooth problems
       linked to this OSI*/
@@ -250,7 +250,8 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  virtual void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds) = 0 ;
+  virtual void initializeDynamicalSystem(const Model& m, double t,
+                                         SP::DynamicalSystem ds) = 0;
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/SchatzmanPaoliOSI.cpp
+++ b/kernel/src/simulationTools/SchatzmanPaoliOSI.cpp
@@ -96,7 +96,8 @@ SP::SiconosMatrix SchatzmanPaoliOSI::WBoundaryConditions(SP::DynamicalSystem ds)
   return _dynamicalSystemsGraph->properties(_dynamicalSystemsGraph->descriptor(ds)).WBoundaryConditions;
 }
 
-void SchatzmanPaoliOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void SchatzmanPaoliOSI::initializeDynamicalSystem(const Model& m, double t,
+                                                  SP::DynamicalSystem ds)
 {
   DEBUG_BEGIN("SchatzmanPaoliOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)\n");
 

--- a/kernel/src/simulationTools/SchatzmanPaoliOSI.hpp
+++ b/kernel/src/simulationTools/SchatzmanPaoliOSI.hpp
@@ -248,7 +248,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/Simulation.cpp
+++ b/kernel/src/simulationTools/Simulation.cpp
@@ -539,21 +539,3 @@ void Simulation::updateOutput(unsigned int)
   }
   DEBUG_END("Simulation::updateOutput()\n");
 }
-
-void Simulation::prepareIntegratorForDS(SP::OneStepIntegrator osi,
-                                        SP::DynamicalSystem ds,
-                                        SP::Model m, double time)
-{
-  // Keep OSI in the set, no effect if already present.
-  insertIntegrator(osi);
-
-  // Associate the OSI to the DS in the topology.
-  assert(_nsds && "Simulation::prepareIntegratorForDS requires an NSDS.");
-  _nsds->topology()->setOSI(ds, osi);
-
-  // Prepare work vectors, etc.
-  // If no Model, or OSI has no DSG yet, assume DS will be initialized
-  // later.  (Typically, during Simulation::initialize())
-  if (m && osi->dynamicalSystemsGraph())
-    osi->initializeDynamicalSystem(*m, time, ds);
-}

--- a/kernel/src/simulationTools/Simulation.hpp
+++ b/kernel/src/simulationTools/Simulation.hpp
@@ -395,18 +395,6 @@ public:
    *  topology updates. */
   virtual void initializeInteraction(double time, SP::Interaction inter);
 
-  /** Associate an OSI with a DynamicalSystem in the graph and
-   *  initialize any necessary graph properties (e.g. work vectors).
-   *  Inserts the integrator into the set if not already present.
-   *
-   *  \param osi The OneStepIntegrator to associate with the DynamicalSystem.
-   *  \param ds The DynamicalSystem, which must be already inserted
-   *            into the NonSmoothDynamicalSystem.
-   *  \param m The Model for initializing the OSI.
-   *  \param time The current time for initializing the OSI. */
-  void prepareIntegratorForDS(SP::OneStepIntegrator osi, SP::DynamicalSystem ds,
-                              SP::Model m=SP::Model(), double time=0);
-
   /** Set an object to automatically manage interactions during the simulation */
   void insertInteractionManager(SP::InteractionManager manager)
     { _interman = manager; }

--- a/kernel/src/simulationTools/ZeroOrderHoldOSI.cpp
+++ b/kernel/src/simulationTools/ZeroOrderHoldOSI.cpp
@@ -56,7 +56,8 @@ ZeroOrderHoldOSI::ZeroOrderHoldOSI():
   _levelMaxForInput =0;
 }
 
-void ZeroOrderHoldOSI::initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds)
+void ZeroOrderHoldOSI::initializeDynamicalSystem(const Model& m, double t,
+                                                 SP::DynamicalSystem ds)
 {
   // Get work buffers from the graph
   VectorOfVectors& workVectors = *_initializeDSWorkVectors(ds);

--- a/kernel/src/simulationTools/ZeroOrderHoldOSI.hpp
+++ b/kernel/src/simulationTools/ZeroOrderHoldOSI.hpp
@@ -94,7 +94,7 @@ public:
    * \param t time of initialization
    * \param ds the dynamical system
    */
-  void initializeDynamicalSystem(Model& m, double t, SP::DynamicalSystem ds);
+  void initializeDynamicalSystem(const Model& m, double t, SP::DynamicalSystem ds);
 
   /** initialization of the work vectors and matrices (properties) related to
    *  one interaction on the graph and needed by the osi

--- a/kernel/src/simulationTools/test/OSNSPTest.cpp
+++ b/kernel/src/simulationTools/test/OSNSPTest.cpp
@@ -38,10 +38,9 @@ void OSNSPTest::init()
   _TD.reset(new TimeDiscretisation(_t0, _h));
   _model.reset(new Model(_t0, _T));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _osi, _model, _t0);
   _sim.reset(new TimeStepping(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_osi, _DS, _model, _t0);
+  _sim->insertIntegrator(_osi);
   _model->setSimulation(_sim);
   _model->initialize();
 }
@@ -88,11 +87,10 @@ void OSNSPTest::testAVI()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _osi.reset(new EulerMoreauOSI(_theta));
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _osi, _model, _t0);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _sim.reset(new TimeStepping(_TD));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_osi, _DS, _model, _t0);
+  _sim->insertIntegrator(_osi);
   SP::AVI osnspb(new AVI());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);

--- a/kernel/src/simulationTools/test/ZOHTest.cpp
+++ b/kernel/src/simulationTools/test/ZOHTest.cpp
@@ -38,10 +38,9 @@ void ZOHTest::init()
   _TD.reset(new TimeDiscretisation(_t0, _h));
   _model.reset(new Model(_t0, _T));
   _sim.reset(new TimeStepping(_TD, 0));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
-  _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _ZOH, _model, _t0);
+  _sim->insertIntegrator(_ZOH);
   _model->setSimulation(_sim);
   _model->initialize();
 }
@@ -158,12 +157,11 @@ void ZOHTest::testMatrixIntegration2()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _ZOH, _model, _t0);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
+  _sim->insertIntegrator(_ZOH);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);
@@ -226,12 +224,11 @@ void ZOHTest::testMatrixIntegration3()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _ZOH, _model, _t0);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
+  _sim->insertIntegrator(_ZOH);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);
@@ -300,12 +297,11 @@ void ZOHTest::testMatrixIntegration4()
   _model.reset(new Model(_t0, _T));
   SP::Interaction inter(new Interaction(nslaw, rel));
   _ZOH.reset(new ZeroOrderHoldOSI());
-  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS);
+  _model->nonSmoothDynamicalSystem()->insertDynamicalSystem(_DS, _ZOH, _model, _t0);
   _model->nonSmoothDynamicalSystem()->link(inter, _DS);
   _model->nonSmoothDynamicalSystem()->setControlProperty(inter, true);
   _sim.reset(new TimeStepping(_TD, 1));
-  _sim->setNonSmoothDynamicalSystemPtr(_model->nonSmoothDynamicalSystem());
-  _sim->prepareIntegratorForDS(_ZOH, _DS, _model, _t0);
+  _sim->insertIntegrator(_ZOH);
   SP::Relay osnspb(new Relay());
   _sim->insertNonSmoothProblem(osnspb);
   _model->setSimulation(_sim);

--- a/kernel/swig/fromXml.py.in
+++ b/kernel/swig/fromXml.py.in
@@ -415,7 +415,6 @@ def buildModelXML(xmlFile):
         exit(1)
 
     # OSI
-    sim.setNonSmoothDynamicalSystemPtr(nsds)
     allOSI = []
     for osiType in dataOSI.keys():
         for osixml in simxml.OneStepIntegrator_Definition.__dict__[osiType]:
@@ -423,7 +422,9 @@ def buildModelXML(xmlFile):
             _additionalInputsOSI(osixml, osi, dataOSI[osiType])
             print(osixml.DS_Concerned)
             for dsN in osixml.DS_Concerned:
-                sim.prepareIntegratorForDS(osi, allDS[dsN], model, sim.nextTime())
+                model.nonSmoothDynamicalSystem().setOSI(allDS[dsN], osi,
+                                                        model, sim.nextTime())
+            sim.insertIntegrator(osi)
             allOSI.append(osi)
 
     # OSNSPB

--- a/kernel/swig/tests/test_lagrangiands_osi.py
+++ b/kernel/swig/tests/test_lagrangiands_osi.py
@@ -92,9 +92,9 @@ def test_lagrangian_and_osis():
     # -- (4) Simulation setup with (1) (2) (3)
     simu = sk.TimeStepping(td, standard, lcp)
     # extra osi must be explicitely inserted into simu and linked to ds
-    simu.setNonSmoothDynamicalSystemPtr(model.nonSmoothDynamicalSystem())
-    simu.prepareIntegratorForDS(bilbao, ds_list['LLDDS+MJB'], model, tinit)
-    simu.prepareIntegratorForDS(bilbao, ds_list['LLDDS+MJB2'], model, tinit)
+    simu.insertIntegrator(bilbao)
+    nsds.setOSI(ds_list['LLDDS+MJB'], bilbao, model, tinit)
+    nsds.setOSI(ds_list['LLDDS+MJB2'], bilbao, model, tinit)
 
     # link simu and model, initialize
     model.setSimulation(simu)

--- a/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
+++ b/mechanics/src/collision/bullet/BulletSpaceFilter.cpp
@@ -516,13 +516,8 @@ void BulletSpaceFilter::addDynamicObject(SP::BulletDS ds,
   }
 
   /* Insert the new DS into the OSI, model, and simulation. */
-  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(ds);
-
-  /* Associate/initialize the OSI */
-  simulation->prepareIntegratorForDS(osi, ds, this->model(), simulation->nextTime());
-
-  /* Partially re-initialize the simulation. */
-  simulation->initialize(this->model(), false);
+  this->model()->nonSmoothDynamicalSystem()->insertDynamicalSystem(
+    ds, osi, this->model(), simulation->nextTime());
 
   /* Re-create the world from scratch */
 #if 0


### PR DESCRIPTION
This is an alternative suggestion to PR #166, a different proposal for #142.  It's a lot more similar to what we had before, except that NSDS::setOSI calls both Topology::setOSI and OSI::initializeDynamicalSystem(), instead of doing it in the SImulation.  This means NSDS::setOSI requires the Model, similar to #166, but it means the DS/OSI link can be set up without creating the Simulation prior, as originally.  It's exactly like calling Topology::setOSI, but with the additional guarantee that OSI work vectors will be initialized.

As mentioned in #142, ZeroOrderHoldOSI::initializeDynamicalSystem requires the Model, an example of why it can't be removed as a parameter, so here instead it is added as a parameter to setOSI.  I also add the OSI as an optional parameter to NSDS::insertDynamicalSystem, so that a DS can be inserted and assigned an OSI in one line, which is the typical use case for multi-OSI examples.
