### PR TITLE
Openblas issue fix

### DIFF
--- a/cmake/FindBLAS.cmake
+++ b/cmake/FindBLAS.cmake
@@ -249,7 +249,7 @@ if(NOT BLAS_FOUND)
       # Right now openblas ships with a cblas.h header which uses double* as type for pointer to double complex, which makes ublas cry since it
       # want to pass std::complex<double>*
       set(BLAS_INCLUDE_SUFFIXES cblas_header)
-      set(INCLUDE_DIR_HINTS ${CMAKE_SOURCE_DIR}/externals/blas_lapack)
+      set(BLAS_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/externals/blas_lapack)
     endif(BLAS_LIBRARIES)
   endif()
   
@@ -405,11 +405,13 @@ if(NOT BLAS_FOUND)
       unset(_dir CACHE)
       set(BLAS_INCLUDE_DIRS ${BLAS_INCLUDE_DIRS} CACHE STRING "Blas headers location." FORCE)
     else() # The case which is supposed to always work
-      find_path(BLAS_INCLUDE_DIRS 
-	NAMES ${BLAS_HEADER}
-	PATH_SUFFIXES ${BLAS_INCLUDE_SUFFIXES}
-        HINTS ${INCLUDE_DIR_HINTS}  ${BLAS_INC_DIR}
-	)
+      if(NOT BLAS_INCLUDE_DIRS)
+        find_path(BLAS_INCLUDE_DIRS 
+	  NAMES ${BLAS_HEADER}
+	  PATH_SUFFIXES ${BLAS_INCLUDE_SUFFIXES}
+          HINTS ${INCLUDE_DIR_HINTS}  ${BLAS_INC_DIR}
+	  )
+      endif()
     endif()
     if(BLAS_INCLUDE_DIRS)
       set(BLAS_FOUND 1 CACHE BOOL "Blas lib and headers have been found.")

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/detail/cblas.h
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/detail/cblas.h
@@ -14,25 +14,6 @@
 #ifndef BOOST_NUMERIC_BINDINGS_BLAS_DETAIL_CBLAS_H
 #define BOOST_NUMERIC_BINDINGS_BLAS_DETAIL_CBLAS_H
 
-
-
-#ifdef HAS_OpenBLAS
-#define OPENBLAS_CONST_FLOAT_CAST(x) reinterpret_cast<const float*>(x)
-#define OPENBLAS_CONST_DOUBLE_CAST(x) reinterpret_cast<const double*>(x)
-#define OPENBLAS_FLOAT_CAST(x) reinterpret_cast<float*>(x)
-#define OPENBLAS_DOUBLE_CAST(x) reinterpret_cast<double*>(x)
-#define OPENBLAS_OPENBLAS_COMPLEX_FLOAT_CAST(x) reinterpret_cast<openblas_complex_float*>(x)
-#define OPENBLAS_OPENBLAS_COMPLEX_DOUBLE_CAST(x) reinterpret_cast<openblas_complex_double*>(x)
-
-#else
-#define OPENBLAS_CONST_FLOAT_CAST(x) x
-#define OPENBLAS_CONST_DOUBLE_CAST(x) x
-#define OPENBLAS_FLOAT_CAST(x) x
-#define OPENBLAS_DOUBLE_CAST(x) x
-#define OPENBLAS_OPENBLAS_COMPLEX_FLOAT_CAST(x) x
-#define OPENBLAS_OPENBLAS_COMPLEX_DOUBLE_CAST(x) x
-#endif
-
 //
 // MKL-specific CBLAS include
 //

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/asum.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/asum.hpp
@@ -33,7 +33,6 @@
 // * for CUBLAS, define BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS
 // * netlib-compatible BLAS is the default
 //
-
 #if defined BOOST_NUMERIC_BINDINGS_BLAS_CBLAS
 #include <boost/numeric/bindings/blas/detail/cblas.h>
 #include <boost/numeric/bindings/blas/detail/cblas_option.hpp>
@@ -56,7 +55,6 @@ namespace blas {
 //
 namespace detail {
 
-  
 #if defined BOOST_NUMERIC_BINDINGS_BLAS_CBLAS
 //
 // Overloaded function for dispatching to
@@ -83,7 +81,7 @@ inline double asum( const int n, const double* x, const int incx ) {
 //
 inline float asum( const int n, const std::complex<float>* x,
         const int incx ) {
-  return cblas_scasum( n, OPENBLAS_CONST_FLOAT_CAST(x), incx );
+    return cblas_scasum( n, x, incx );
 }
 
 //
@@ -93,7 +91,7 @@ inline float asum( const int n, const std::complex<float>* x,
 //
 inline double asum( const int n, const std::complex<double>* x,
         const int incx ) {
-  return cblas_dzasum( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx );
+    return cblas_dzasum( n, x, incx );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/axpy.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/axpy.hpp
@@ -84,7 +84,7 @@ inline void axpy( const int n, const double a, const double* x,
 inline void axpy( const int n, const std::complex<float> a,
         const std::complex<float>* x, const int incx, std::complex<float>* y,
         const int incy ) {
-  cblas_caxpy( n, OPENBLAS_CONST_FLOAT_CAST(&a), OPENBLAS_CONST_FLOAT_CAST(x), incx, OPENBLAS_FLOAT_CAST(y), incy );
+    cblas_caxpy( n, &a, x, incx, y, incy );
 }
 
 //
@@ -95,7 +95,7 @@ inline void axpy( const int n, const std::complex<float> a,
 inline void axpy( const int n, const std::complex<double> a,
         const std::complex<double>* x, const int incx,
         std::complex<double>* y, const int incy ) {
-  cblas_zaxpy( n, OPENBLAS_CONST_DOUBLE_CAST(&a), OPENBLAS_CONST_DOUBLE_CAST(x), incx, OPENBLAS_DOUBLE_CAST(y), incy );
+    cblas_zaxpy( n, &a, x, incx, y, incy );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/copy.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/copy.hpp
@@ -83,7 +83,7 @@ inline void copy( const int n, const double* x, const int incx, double* y,
 //
 inline void copy( const int n, const std::complex<float>* x, const int incx,
         std::complex<float>* y, const int incy ) {
-  cblas_ccopy( n, OPENBLAS_CONST_FLOAT_CAST(x), incx, OPENBLAS_FLOAT_CAST(y), incy );
+    cblas_ccopy( n, x, incx, y, incy );
 }
 
 //
@@ -93,7 +93,7 @@ inline void copy( const int n, const std::complex<float>* x, const int incx,
 //
 inline void copy( const int n, const std::complex<double>* x, const int incx,
         std::complex<double>* y, const int incy ) {
-  cblas_zcopy( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx, OPENBLAS_DOUBLE_CAST(y), incy );
+    cblas_zcopy( n, x, incx, y, incy );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/dot.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/dot.hpp
@@ -84,7 +84,7 @@ inline double dot( const int n, const double* x, const int incx,
 inline std::complex<float> dot( const int n, const std::complex<float>* x,
         const int incx, const std::complex<float>* y, const int incy ) {
     std::complex<float> result;
-    cblas_cdotu_sub( n, OPENBLAS_CONST_FLOAT_CAST(x), incx, OPENBLAS_CONST_FLOAT_CAST(y), incy, OPENBLAS_OPENBLAS_COMPLEX_FLOAT_CAST(&result) );
+    cblas_cdotu_sub( n, x, incx, y, incy, &result );
     return result;
 }
 
@@ -96,7 +96,7 @@ inline std::complex<float> dot( const int n, const std::complex<float>* x,
 inline std::complex<double> dot( const int n, const std::complex<double>* x,
         const int incx, const std::complex<double>* y, const int incy ) {
     std::complex<double> result;
-    cblas_zdotu_sub( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx, OPENBLAS_CONST_DOUBLE_CAST(y), incy, OPENBLAS_OPENBLAS_COMPLEX_DOUBLE_CAST(&result) );
+    cblas_zdotu_sub( n, x, incx, y, incy, &result );
     return result;
 }
 

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/dotc.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/dotc.hpp
@@ -64,7 +64,7 @@ namespace detail {
 inline std::complex<float> dotc( const int n, const std::complex<float>* x,
         const int incx, const std::complex<float>* y, const int incy ) {
     std::complex<float> result;
-    cblas_cdotc_sub( n, OPENBLAS_CONST_FLOAT_CAST(x), incx, OPENBLAS_CONST_FLOAT_CAST(y), incy, OPENBLAS_OPENBLAS_COMPLEX_FLOAT_CAST(&result) );
+    cblas_cdotc_sub( n, x, incx, y, incy, &result );
     return result;
 }
 
@@ -76,7 +76,7 @@ inline std::complex<float> dotc( const int n, const std::complex<float>* x,
 inline std::complex<double> dotc( const int n, const std::complex<double>* x,
         const int incx, const std::complex<double>* y, const int incy ) {
     std::complex<double> result;
-    cblas_zdotc_sub( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx, OPENBLAS_CONST_DOUBLE_CAST(y), incy, OPENBLAS_OPENBLAS_COMPLEX_DOUBLE_CAST(&result ));
+    cblas_zdotc_sub( n, x, incx, y, incy, &result );
     return result;
 }
 

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/iamax.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/iamax.hpp
@@ -82,7 +82,7 @@ inline std::ptrdiff_t iamax( const int n, const double* x,
 //
 inline std::ptrdiff_t iamax( const int n, const std::complex<float>* x,
         const int incx ) {
-  return cblas_icamax( n, OPENBLAS_CONST_FLOAT_CAST(x), incx );
+    return cblas_icamax( n, x, incx );
 }
 
 //
@@ -92,7 +92,7 @@ inline std::ptrdiff_t iamax( const int n, const std::complex<float>* x,
 //
 inline std::ptrdiff_t iamax( const int n, const std::complex<double>* x,
         const int incx ) {
-  return cblas_izamax( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx );
+    return cblas_izamax( n, x, incx );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/nrm2.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/nrm2.hpp
@@ -81,7 +81,7 @@ inline double nrm2( const int n, const double* x, const int incx ) {
 //
 inline float nrm2( const int n, const std::complex<float>* x,
         const int incx ) {
-  return cblas_scnrm2( n, OPENBLAS_CONST_FLOAT_CAST(x), incx );
+    return cblas_scnrm2( n, x, incx );
 }
 
 //
@@ -91,7 +91,7 @@ inline float nrm2( const int n, const std::complex<float>* x,
 //
 inline double nrm2( const int n, const std::complex<double>* x,
         const int incx ) {
-  return cblas_dznrm2( n, OPENBLAS_CONST_DOUBLE_CAST(x), incx );
+    return cblas_dznrm2( n, x, incx );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/scal.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/scal.hpp
@@ -81,7 +81,7 @@ inline void scal( const int n, const double a, double* x, const int incx ) {
 //
 inline void scal( const int n, const float a, std::complex<float>* x,
         const int incx ) {
-  cblas_csscal( n, a, OPENBLAS_FLOAT_CAST(x), incx );
+    cblas_csscal( n, a, x, incx );
 }
 
 //
@@ -91,7 +91,7 @@ inline void scal( const int n, const float a, std::complex<float>* x,
 //
 inline void scal( const int n, const double a, std::complex<double>* x,
         const int incx ) {
-  cblas_zdscal( n, a, OPENBLAS_DOUBLE_CAST(x), incx );
+    cblas_zdscal( n, a, x, incx );
 }
 
 //
@@ -101,7 +101,7 @@ inline void scal( const int n, const double a, std::complex<double>* x,
 //
 inline void scal( const int n, const std::complex<float> a,
         std::complex<float>* x, const int incx ) {
-  cblas_cscal( n, OPENBLAS_CONST_FLOAT_CAST(&a), OPENBLAS_FLOAT_CAST(x), incx );
+    cblas_cscal( n, &a, x, incx );
 }
 
 //
@@ -111,7 +111,7 @@ inline void scal( const int n, const std::complex<float> a,
 //
 inline void scal( const int n, const std::complex<double> a,
         std::complex<double>* x, const int incx ) {
-  cblas_zscal( n, OPENBLAS_CONST_DOUBLE_CAST(&a), OPENBLAS_DOUBLE_CAST(x), incx );
+    cblas_zscal( n, &a, x, incx );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS

--- a/externals/numeric_bindings/boost/numeric/bindings/blas/level1/swap.hpp
+++ b/externals/numeric_bindings/boost/numeric/bindings/blas/level1/swap.hpp
@@ -83,7 +83,7 @@ inline void swap( const int n, double* x, const int incx, double* y,
 //
 inline void swap( const int n, std::complex<float>* x, const int incx,
         std::complex<float>* y, const int incy ) {
-  cblas_cswap( n, OPENBLAS_FLOAT_CAST(x), incx, OPENBLAS_FLOAT_CAST(y), incy );
+    cblas_cswap( n, x, incx, y, incy );
 }
 
 //
@@ -93,7 +93,7 @@ inline void swap( const int n, std::complex<float>* x, const int incx,
 //
 inline void swap( const int n, std::complex<double>* x, const int incx,
         std::complex<double>* y, const int incy ) {
-  cblas_zswap( n, OPENBLAS_DOUBLE_CAST(x), incx, OPENBLAS_DOUBLE_CAST(y), incy );
+    cblas_zswap( n, x, incx, y, incy );
 }
 
 #elif defined BOOST_NUMERIC_BINDINGS_BLAS_CUBLAS


### PR DESCRIPTION
if openblas library is found, cblas.h is not searched anymore, it is the one provided under externals/blas_lapack/cblas_header

for more information see @xhub d28d3ca1be273094bb3eb06a826b357c71c01afd

the only modification to this commit is to always use the provided (and official) cblas.h

The compilation is ok on my ubuntu 17.04 + openblas:

-- Try to find blas in openblas ...
-- Looking for cblas_sgemm
-- Looking for cblas_sgemm - found
-- Looking for Fortran sgemm
-- Looking for Fortran sgemm - found
-- Blas libraries have been found : /usr/lib/libopenblas.so. We now turn to headers.
-- pkghints:
-- BLAS_INC_DIR:/usr/include
-- Found a library with BLAS API (openblas).
    Blas libraries : /usr/lib/libopenblas.so.
    Blas headers : cblas.h in /home/maurice/src/git/siconos/externals/blas_lapack.
 
