### PR TITLE
[kernel,examples] Put ref file comparison code in ioMatrix.

### DIFF
--- a/examples/Electronics/DiodeBridgeCapFilter/DiodeBridgeCapFilter.cpp
+++ b/examples/Electronics/DiodeBridgeCapFilter/DiodeBridgeCapFilter.cpp
@@ -235,32 +235,10 @@ int main(int argc, char* argv[])
     ioMatrix::write("DiodeBridgeCapFilter.dat", "ascii", dataPlot, "noDim");
 
     // Comparison with a reference file
-    std::cout << "Comparison with a reference file" << std::endl;
-    SimpleMatrix dataPlotRef(dataPlot);
-    dataPlotRef.zero();
-    ioMatrix::read("DiodeBridgeCapFilter.ref", "ascii", dataPlotRef);
-    SP::SiconosVector err(new SiconosVector(dataPlot.size(1)));
-    (dataPlot - dataPlotRef).normInfByColumn(err);
-    err->display();
-    double error = 0.0;
-    for (unsigned int i = 0; i < 3; ++i)
-    {
-      if (error < (*err)(i))
-        error = (*err)(i);
-    }
-
-    std::cout << "Error = "<< error << std::endl;
-    if (error > 1e-12)
-    {
-      (dataPlot - dataPlotRef).display();
-      std::cout << "Warning. The results is rather different from the reference file." << std::endl;
-      std::cout << "Error = "<< error << std::endl;
+    double error=0.0, eps=1e-12;
+    if (ioMatrix::compareRefFile(dataPlot, "DiodeBridgeCapFilter.ref", eps, error)
+        && error > eps)
       return 1;
-    }
-
-
-
-
   }
 
   // --- Exceptions handling ---

--- a/kernel/src/utils/SiconosAlgebra/ioMatrix.cpp
+++ b/kernel/src/utils/SiconosAlgebra/ioMatrix.cpp
@@ -23,6 +23,8 @@
 #include "ioMatrix.hpp"
 #include "SiconosMatrix.hpp"
 #include "SiconosMatrixException.hpp"
+#include "SimpleMatrix.hpp"
+#include "SiconosVector.hpp"
 #include <boost/numeric/ublas/io.hpp>
 #include <boost/numeric/ublas/matrix_sparse.hpp>
 
@@ -179,7 +181,60 @@ bool write(const std::string& fileName, const std::string& mode, const SiconosMa
   return true;
 }
 
+bool compareRefFile(const SimpleMatrix& data, std::string filename, double epsilon,
+                    double& error, SP::SimpleMatrix* ref,
+                    std::string mode, bool verbose)
+{
+  SP::SimpleMatrix r;
+  if (!ref) ref = &r;
+  *ref = std11::make_shared<SimpleMatrix>(data);
+  (*ref)->zero();
+  bool compare = false;
+
+  try {
+    compare = ioMatrix::read(filename, mode, **ref);
+  }
+  catch (SiconosMatrixException &e) {
+    if (verbose)
+      std::cout << "Warning: reference file " << filename
+                << " not found, no comparison performed." << std::endl;
+  }
+  if (!compare)
+    return false;
+
+  if (verbose)
+    std::cout << "Comparison with reference file " << filename << std::endl;
+
+  SP::SiconosVector err(new SiconosVector(data.size(1)));
+  (data - **ref).normInfByColumn(err);
+
+  if (verbose)
+    err->display();
+
+  /* Scalar error = max of columns */
+  error = 0.0;
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    if (error < (*err)(i))
+      error = (*err)(i);
+  }
+
+  if (verbose)
+    std::cout << "Error = " << error << std::endl;
+  if (error > epsilon)
+  {
+    if (verbose)
+    {
+      std::cout << "Warning. The results are rather different from the reference file." << std::endl;
+      std::cout << "Error = "<< error << std::endl;
+    }
+  }
+
+  return true;
 }
+
+} // namespace ioMatrix
+
 // To be used later ... ?
 //   template <class T, class iterator1> friend void write( const T& obj, iterator1 row, std::ofstream outfile)
 //   {

--- a/kernel/src/utils/SiconosAlgebra/ioMatrix.hpp
+++ b/kernel/src/utils/SiconosAlgebra/ioMatrix.hpp
@@ -56,6 +56,20 @@ bool read(const std::string& fileName, const std::string& mode, SiconosMatrix& m
 */
 bool write(const std::string& fileName, const std::string& mode, const SiconosMatrix& m, const std::string& outputType = "python");
 
+/** Function to load data from a file and compare it with the provided
+ * data.  Returns true if the file was loaded and the comparison was
+ * performed.  Caller needs to check diff <= epsilon to verify the
+ * result.
+ * \param data The data to compare against the file.
+ * \param filename The name of the file to load and compare.
+ * \param epsilon The comparison threshold.
+ * \param verbose True to print verbose output.
+ * \param ref If provided, loaded matrix is returned in this pointer.
+ * \param diff If non-zero, scalar-valued difference is returned in this location.
+ */
+bool compareRefFile(const SimpleMatrix& data, std::string filename, double epsilon,
+                    double& error, SP::SimpleMatrix* ref=0,
+                    std::string mode="ascii", bool verbose=true);
 }
 
 #endif


### PR DESCRIPTION
I was thinking about packaging examples, and it seems to me that the ref files are used to double the examples as tests, which is okay, but for distribution they take a lot of room.

```
# cd ~/projects/debian/siconos/examples
$ du -sh .
268M	.

# remove ref files
$ find . -name \*.ref -delete

$ du -sh .
112M	.

$ find . -type f ! -name \*.cpp -a ! -name \*.c -a ! -name \*.py  -a ! -name \*.hpp -a ! -name \*.h -delete

$ du -sh .
5,5M
```

Not sure about removing everything else, but I propose that examples should run if the ref files are not present.  This PR proposes standardizing the ref-file comparison code and moving it into ioMatrix. I haven't done the work to change all examples to use this function yet, but I would like feedback on the idea.

It adds the function ioMatrix::compareRefFile, and one example of usage in DiodeBridgeCapFilter (chosen at random), changing the end of the program to,

```C++
    // --- elapsed time computing ---                                                    
    cout << "time = " << t.elapsed() << endl;                                            
                                                                                         
    // Number of time iterations                                                         
    cout << "Number of iterations done: " << k << endl;                                  
                                                                                         
    // dataPlot (ascii) output                                                           
    ioMatrix::write("DiodeBridgeCapFilter.dat", "ascii", dataPlot, "noDim");             
                                                                                         
    // Comparison with a reference file                                                  
    double error=0.0, eps=1e-12;                                                         
    if (ioMatrix::compareRefFile(dataPlot, "DiodeBridgeCapFilter.ref", eps, error)       
        && error > eps)                                                                  
      return 1;
```

In other words, if the ref file is available, then the program exits with 0 or 1 depending on the comparison.  Otherwise if the ref file is not available, the program exits normally and prints a warning.