### PR TITLE
mechanics-occ

### DIFF
--- a/examples/Mechanics/OCC_Examples/occ_bouncing_ball.py
+++ b/examples/Mechanics/OCC_Examples/occ_bouncing_ball.py
@@ -4,7 +4,7 @@
 # Example of a bouncing ball with OpenCascade contactors
 #
 
-from siconos.mechanics.collision.tools import Contactor
+from siconos.mechanics.collision.tools import Volume, Contactor
 from siconos.io.mechanics_io import Hdf5
 from siconos import numerics
 import siconos.io.mechanics_io
@@ -24,7 +24,7 @@ with Hdf5() as io:
     io.addOccShape('Ground', ground)
 
     io.addObject('sphere',
-                 [Contactor('Sphere', contact_type='Face', contact_index=0)],
+                 [Volume('Sphere'), Contactor('Sphere', contact_type='Face', contact_index=0)],
                  mass=1, translation=[0, 0, 10], velocity=[0, 0, 0, 0, 0, 0])
 
     io.addObject('ground',
@@ -32,9 +32,9 @@ with Hdf5() as io:
                  mass=0, translation=[0, 0, 0])
 
     io.addInteraction('sphere-ground',
-                      'sphere', 'Sphere-0',
+                      'sphere', 'Sphere-1',
                       'ground', 'Ground-0',
-                      distance_calculator='cadmbtb',
+                      distance_calculator='occ',
                       offset=0.01)
 
     io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.9)

--- a/examples/Mechanics/OCC_Examples/occ_slider_crank.py
+++ b/examples/Mechanics/OCC_Examples/occ_slider_crank.py
@@ -4,13 +4,8 @@ from siconos.mechanics.collision.tools import Volume, Contactor, Shape
 from siconos.io.mechanics_io import Hdf5
 import siconos.io.mechanics_io
 
-from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
-from OCC.gp import gp_Pnt
-
 siconos.io.mechanics_io.set_implementation('original')
 siconos.io.mechanics_io.set_backend('occ')
-
-sphere = BRepPrimAPI_MakeSphere(0.025).Shape()
 
 l1 = 0.153    # crank length
 l2 = 0.306    # connecting rod length
@@ -24,9 +19,7 @@ w30 = 0.      # initial angular speed for the slider
 with Hdf5() as io:
 
     io.addPluginSource('plugin', 'SliderCrankPlugin/SliderCrankPlugin.cpp')
-    
-    io.addOccShape('Sphere', sphere)
-    
+
     io.addShapeDataFromFile('body1',
                             '../Mechanisms/SliderCrank/CAD/body1.step')
     io.addShapeDataFromFile('body2',
@@ -55,7 +48,7 @@ with Hdf5() as io:
 #    io.addObject('Artefact', [Shape(shape_data='Artefact',
 #                                    instance_name='artefact')],
 #                 translation=[0., 0., 0.])
-    
+
     io.addObject('part1', [Volume(shape_data='body1',
                                   instance_name='Body1',
                                   relative_translation=[-0.5*l1, 0., 0.],
@@ -166,7 +159,7 @@ with Hdf5() as io:
                       body2_name='chamber', contactor2_name='Chamber_contact0',
                       distance_calculator='cadmbtb',
                       offset=0.024)
-    
+
     io.addInteraction('contact11',
                       body1_name='slider', contactor1_name='Contact_b_f0',
                       body2_name='chamber', contactor2_name='Chamber_contact1',
@@ -267,8 +260,8 @@ with Hdf5() as io:
                            'SliderCrankPlugin', 'externalForcesS')
 
     io.addExternalBCFunction('fbc', 'part1', [4],
-                             'SliderCrankPlugin','prescribedvelocityB1')
-    
+                             'SliderCrankPlugin', 'prescribedvelocityB1')
+
     io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.4)
 
 with Hdf5(mode='r+') as io:

--- a/examples/Mechanics/OCC_Examples/occ_slider_crank.py
+++ b/examples/Mechanics/OCC_Examples/occ_slider_crank.py
@@ -266,7 +266,8 @@ with Hdf5() as io:
     io.addExternalFunction('f3', 'slider', 'setComputeFExtFunction',
                            'SliderCrankPlugin', 'externalForcesS')
 
-    
+    io.addExternalBCFunction('fbc', 'part1', [4],
+                             'SliderCrankPlugin','prescribedvelocityB1')
     
     io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.4)
 

--- a/examples/Mechanics/OCC_Examples/occ_slider_crank.py
+++ b/examples/Mechanics/OCC_Examples/occ_slider_crank.py
@@ -23,6 +23,8 @@ w30 = 0.      # initial angular speed for the slider
 
 with Hdf5() as io:
 
+    io.addPluginSource('plugin', 'SliderCrankPlugin/SliderCrankPlugin.cpp')
+    
     io.addOccShape('Sphere', sphere)
     
     io.addShapeDataFromFile('body1',
@@ -255,6 +257,16 @@ with Hdf5() as io:
                       distance_calculator='cadmbtb',
                       offset=0.024)
 
+    io.addExternalFunction('f1', 'part1', 'setComputeFExtFunction',
+                           'SliderCrankPlugin', 'externalForcesB1')
+
+    io.addExternalFunction('f2', 'part2', 'setComputeFExtFunction',
+                           'SliderCrankPlugin', 'externalForcesB2')
+
+    io.addExternalFunction('f3', 'slider', 'setComputeFExtFunction',
+                           'SliderCrankPlugin', 'externalForcesS')
+
+    
     
     io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.4)
 
@@ -262,6 +274,6 @@ with Hdf5(mode='r+') as io:
 
     io.run(with_timer=True,
            t0=0,
-           T=1,
+           T=10,
            h=0.0005,
            Newton_max_iter=5)

--- a/examples/Mechanics/OCC_Examples/occ_slider_crank.py
+++ b/examples/Mechanics/OCC_Examples/occ_slider_crank.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from siconos.mechanics.collision.tools import Shape, Contactor
+from siconos.mechanics.collision.tools import Volume, Contactor
 from siconos.io.mechanics_io import Hdf5
 import siconos.io.mechanics_io
 
@@ -47,18 +47,18 @@ with Hdf5() as io:
     io.addShapeDataFromFile('AxisBody',
                             '../Mechanisms/SliderCrank/CAD/AxisBody2.stp')
 
-    io.addObject('part1', [Shape(shape_data='body1',
-                                 instance_name='Body1',
-                                 relative_translation=[-0.5*l1, 0., 0.],
-                                 relative_orientation=[(0, 1, 0), 0. ])],
+    io.addObject('part1', [Volume(shape_data='body1',
+                                  instance_name='Body1',
+                                  relative_translation=[-0.5*l1, 0., 0.],
+                                  relative_orientation=[(0, 1, 0), 0. ])],
                  translation=[0.5*l1, 0., 0.],
                  velocity=[0., 0., -0.5 * w10 * l1, 0., w10, 0.],
                  mass=0.038,
                  inertia=[7.4e-5, 1, 1.])
 
-    io.addObject('part2', [Shape(shape_data='body2',
-                                 instance_name='Body2',
-                                 relative_translation=[-0.5 * l2, 0., 0.])],
+    io.addObject('part2', [Volume(shape_data='body2',
+                                  instance_name='Body2',
+                                  relative_translation=[-0.5 * l2, 0., 0.])],
                  translation=[l1 + 0.5*l2, 0., 0.],
                  orientation=[0., 0., 1., 0.],
                  velocity=[0., 0., -0.5 * w10 * l1, 0., w20, 0.],

--- a/examples/Mechanics/OCC_Examples/occ_slider_crank.py
+++ b/examples/Mechanics/OCC_Examples/occ_slider_crank.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from siconos.mechanics.collision.tools import Volume, Contactor
+from siconos.mechanics.collision.tools import Volume, Contactor, Shape
 from siconos.io.mechanics_io import Hdf5
 import siconos.io.mechanics_io
 
@@ -47,6 +47,13 @@ with Hdf5() as io:
     io.addShapeDataFromFile('AxisBody',
                             '../Mechanisms/SliderCrank/CAD/AxisBody2.stp')
 
+    io.addShapeDataFromFile('Artefact',
+                            '../Mechanisms/SliderCrank/CAD/artefact2.step')
+
+#    io.addObject('Artefact', [Shape(shape_data='Artefact',
+#                                    instance_name='artefact')],
+#                 translation=[0., 0., 0.])
+    
     io.addObject('part1', [Volume(shape_data='body1',
                                   instance_name='Body1',
                                   relative_translation=[-0.5*l1, 0., 0.],
@@ -65,36 +72,77 @@ with Hdf5() as io:
                  mass=0.038,
                  inertia=[5.9e-4, 1., 1.])
 
-    io.addObject('slider', [Contactor(shape_data='Sphere',
-                                      instance_name='cslid',
-                                      contact_type='Face',
-                                      contact_index=0,
-                                      relative_translation=[-a, 0., 0.])],
-                            # Contactor(
-                            #     instance_name='Contact_b',
-                            #     shape_data='Contact_b_cyl',
-                            #     contact_type='Edge',
-                            #     contact_index=0,
-                            #     relative_translation=[-a, 0., 0.]),
-                            # Contactor(
-                            #     instance_name='Contact_h',
-                            #     shape_data='Contact_h_cyl',
-                            #     contact_type='Edge',
-                            #     contact_index=0,
-                            #     relative_translation=[-a, 0., 0.])],
+    io.addObject('slider', [
+        Shape(shape_data='Slider',
+              instance_name='cslid',
+              relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_b_f1',
+            shape_data='Contact_b_cyl',
+            contact_type='Face',
+            contact_index=1,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_h_f1',
+            shape_data='Contact_h_cyl',
+            contact_type='Face',
+            contact_index=1,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_b_f0',
+            shape_data='Contact_b_cyl',
+            contact_type='Face',
+            contact_index=0,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_h_f0',
+            shape_data='Contact_h_cyl',
+            contact_type='Face',
+            contact_index=0,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_b_e1',
+            shape_data='Contact_b_cyl',
+            contact_type='Edge',
+            contact_index=1,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_h_e1',
+            shape_data='Contact_h_cyl',
+            contact_type='Edge',
+            contact_index=1,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_b_e0',
+            shape_data='Contact_b_cyl',
+            contact_type='Edge',
+            contact_index=0,
+            relative_translation=[-a, 0., 0.]),
+        Contactor(
+            instance_name='Contact_h_e0',
+            shape_data='Contact_h_cyl',
+            contact_type='Edge',
+            contact_index=0,
+            relative_translation=[-a, 0., 0.])],
                  translation=[l1 + l2 + a, 0., 0.],
-                 velocity=[0., 0., 0., 0., w30, 0.],
+                 velocity=[-0., 0., 0., 0., w30, 0.],
                  mass=0.076,
                  inertia=[2.7e-6, 1., 1.])
 
     # a static object (mass=0)
     io.addObject('chamber', [Contactor(
-        instance_name='Chamber_contact',
+        instance_name='Chamber_contact0',
         shape_data='Chamber',
         contact_type='Face',
         contact_index=0,
+        relative_translation=[0, 0, 0]),
+                            Contactor(
+        instance_name='Chamber_contact1',
+        shape_data='Chamber',
+        contact_type='Face',
+        contact_index=1,
         relative_translation=[0, 0, 0])],
-                 translation=[0, 0, 0])
+                translation=[0, 0, 0])
 
     io.addJoint('joint1',  'part1',
                 points=[[0., 0., 0.]],
@@ -102,28 +150,118 @@ with Hdf5() as io:
                 joint_class='PivotJointR')
 
     io.addJoint('joint2', 'part2', 'slider',
-                points=[[-0.5*l2, 0., 0.]],
-                axes=[[0., 1., 0]],
+                pivot_point=[0.5*l2, 0., 0.],
+                axis=[0., 1., 0],
                 joint_class='PivotJointR')
 
     io.addJoint('joint3', 'part1', 'part2',
-                points=[[0.5*l1, 0., 0.]],
-                axes=[[0., 1., 0.]],
+                pivot_point=[l1, 0., 0.],
+                axis=[0., 1., 0.],
                 joint_class='PivotJointR')
 
-    io.addInteraction('contact1',
-                      body1_name='slider', contactor1_name='cslid',
-                      body2_name='chamber', contactor2_name='Chamber_contact',
+    io.addInteraction('contact10',
+                      body1_name='slider', contactor1_name='Contact_b_f0',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
                       distance_calculator='cadmbtb',
-                      offset=0.0024)
-
-    io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.9)
+                      offset=0.024)
     
+    io.addInteraction('contact11',
+                      body1_name='slider', contactor1_name='Contact_b_f0',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact20',
+                      body1_name='slider', contactor1_name='Contact_h_f0',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact21',
+                      body1_name='slider', contactor1_name='Contact_h_f0',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact30',
+                      body1_name='slider', contactor1_name='Contact_b_f1',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact31',
+                      body1_name='slider', contactor1_name='Contact_b_f1',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact40',
+                      body1_name='slider', contactor1_name='Contact_h_f1',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact41',
+                      body1_name='slider', contactor1_name='Contact_h_f1',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact50',
+                      body1_name='slider', contactor1_name='Contact_b_e0',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact51',
+                      body1_name='slider', contactor1_name='Contact_b_e0',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact60',
+                      body1_name='slider', contactor1_name='Contact_h_e0',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact61',
+                      body1_name='slider', contactor1_name='Contact_h_e0',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact70',
+                      body1_name='slider', contactor1_name='Contact_b_e1',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact71',
+                      body1_name='slider', contactor1_name='Contact_b_e1',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact80',
+                      body1_name='slider', contactor1_name='Contact_h_e1',
+                      body2_name='chamber', contactor2_name='Chamber_contact0',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    io.addInteraction('contact81',
+                      body1_name='slider', contactor1_name='Contact_h_e1',
+                      body2_name='chamber', contactor2_name='Chamber_contact1',
+                      distance_calculator='cadmbtb',
+                      offset=0.024)
+
+    
+    io.addNewtonImpactFrictionNSL('contact', mu=0.3, e=0.4)
+
 with Hdf5(mode='r+') as io:
 
     io.run(with_timer=True,
            t0=0,
            T=1,
            h=0.0005,
-           Newton_max_iter=1,
-           set_external_forces=lambda x: None)
+           Newton_max_iter=5)

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1307,9 +1307,6 @@ class Hdf5():
 
             if number is not None:
                 body.setNumber(number)
-        else:
-            # a static object
-            body = None
 
         ref_shape = {ctor.instance_name: occ.OccContactShape(
             self._shape.get(ctor.shape_name,

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -1533,13 +1533,23 @@ class Hdf5():
             body1_name = pinter.attrs['body1_name']
             body2_name = pinter.attrs['body2_name']
 
-            ds1 = \
-                  Kernel.cast_NewtonEulerDS(topo.getDynamicalSystem(body1_name))
+            try:
+                ds1 = \
+                      Kernel.cast_NewtonEulerDS(
+                          topo.getDynamicalSystem(body1_name))
+            except:
+                ds1 = None
+
             try:
                 ds2 = \
-                    Kernel.cast_NewtonEulerDS(topo.getDynamicalSystem(body2_name))
+                      Kernel.cast_NewtonEulerDS(
+                          topo.getDynamicalSystem(body2_name))
             except:
                 ds2 = None
+
+            # static object in second
+            if ds1 is None:
+                ds2, ds1 = ds1, ds2
 
             contactor1_name = pinter.attrs.get('contactor1_name', None)
             contactor2_name = pinter.attrs.get('contactor2_name', None)

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -574,7 +574,7 @@ class ShapeCollection():
                                      tmpf[1], self._collision_margin, scale=scale)
                     else:
                         assert False
-                elif self.attributes(shape_name)['type'] in['step', 'stp']:
+                elif self.attributes(shape_name)['type'] in ['step', 'stp']:
                     from OCC.STEPControl import STEPControl_Reader
                     from OCC.BRep import BRep_Builder
                     from OCC.TopoDS import TopoDS_Compound
@@ -1484,7 +1484,7 @@ class Hdf5():
             #    self._model.nonSmoothDynamicalSystem().\
             #        link(joint_inter, ds1)
 
-    def importPermanentInteraction(self, name):
+    def importPermanentInteractions(self, name):
         """
         """
         if (self._broadphase is not None and 'input' in self._data
@@ -1504,8 +1504,18 @@ class Hdf5():
             except:
                 ds2 = None
 
-            contactor1_name = pinter.attrs['contactor1_name']
-            contactor2_name = pinter.attrs['contactor2_name']
+            contactor1_name = pinter.attrs.get('contactor1_name', None)
+            contactor2_name = pinter.attrs.get('contactor2_name', None)
+
+            if contactor1_name is None:
+                contactor1_names = self._occ_contactors[body1_name].keys()
+            else:
+                contactor1_names = [contactor1_name]
+
+            if contactor2_name is None:
+                contactor2_names = self._occ_contactors[body2_name].keys()
+            else:
+                contactor2_names = [contactor2_name]
 
             distance_calculator = pinter.attrs['distance_calculator']
             offset = pinter.attrs['offset']
@@ -1513,53 +1523,40 @@ class Hdf5():
             body1 = self._input[body1_name]
             body2 = self._input[body2_name]
 
-            ctr1 = body1[contactor1_name]
-            ctr2 = body2[contactor2_name]
-
-            cg1 = int(ctr1.attrs['group'])
-            cg2 = int(ctr2.attrs['group'])
-            nslaw = self._broadphase.nslaw(cg1, cg2)
-
-            cocs1 = self._occ_contactors[body1_name][contactor1_name]
-            cocs2 = self._occ_contactors[body2_name][contactor2_name]
-
-            # else:
-            #     topods2 = self._shape.get(ctr2.attrs['name'])
-            #     self._keep.append(topods2)
-            #     ocs2 = occ.OccContactShape(topods2)
-            #if self.verbose:
-            #    print (body1_name, self._occ_contactors[body1_name])
-
-            #     index2 = int(ctr2.attrs['contact_index'])
-
-            #     ctact_t2 = ctr2.attrs['type']
-
-            #     ctactbuild = {'Face': occ.OccContactFace,
-            #                   'Edge': occ.OccContactEdge}
-
-            #     cocs2 = ctactbuild[ctact_t2](ocs2, index2)
-
-            cp1 = occ.ContactPoint(cocs1)
-            cp2 = occ.ContactPoint(cocs2)
-
             real_dist_calc = {'cadmbtb': occ.CadmbtbDistanceType,
                               'occ': occ.OccDistanceType}
 
-            relation = occ.OccR(cp1, cp2,
-                                real_dist_calc[distance_calculator]())
+            for contactor1_name in contactor1_names:
+                for contactor2_name in contactor2_names:
+                    ctr1 = body1[contactor1_name]
+                    ctr2 = body2[contactor2_name]
 
-            relation.setOffset(offset)
+                    cg1 = int(ctr1.attrs['group'])
+                    cg2 = int(ctr2.attrs['group'])
+                    nslaw = self._broadphase.nslaw(cg1, cg2)
 
-            inter = Interaction(nslaw, relation)
+                    cocs1 = self._occ_contactors[body1_name][contactor1_name]
+                    cocs2 = self._occ_contactors[body2_name][contactor2_name]
 
-            if ds2 is not None:
-                self._model.nonSmoothDynamicalSystem().link(inter, ds1, ds2)
-            else:
-                self._model.nonSmoothDynamicalSystem().link(inter, ds1)
+                    cp1 = occ.ContactPoint(cocs1)
+                    cp2 = occ.ContactPoint(cocs2)
 
-            # keep pointers
-            self._keep.append([cocs1, cocs2, cp1,
-                               cp2, relation])
+                    relation = occ.OccR(cp1, cp2,
+                                        real_dist_calc[distance_calculator]())
+
+                    relation.setOffset(offset)
+
+                    inter = Interaction(nslaw, relation)
+
+                    if ds2 is not None:
+                        self._model.nonSmoothDynamicalSystem().link(inter, ds1,
+                                                                    ds2)
+                    else:
+                        self._model.nonSmoothDynamicalSystem().link(inter, ds1)
+
+                    # keep pointers
+                    self._keep.append([cocs1, cocs2, cp1,
+                                       cp2, relation])
 
     def importObject(self, name, body_class=None, shape_class=None,
                      face_class=None, edge_class=None, birth=False,
@@ -1833,7 +1830,7 @@ class Hdf5():
                 self.importBoundaryConditions(name)
 
             for name in self.permanent_interactions():
-                self.importPermanentInteraction(name)
+                self.importPermanentInteractions(name)
 
     def currentTime(self):
         if self._initializing:
@@ -2276,8 +2273,8 @@ class Hdf5():
             self._shapeid[name] = shape.attrs['id']
             self._number_of_shapes += 1
 
-    def addInteraction(self, name, body1_name, contactor1_name,
-                       body2_name, contactor2_name,
+    def addInteraction(self, name, body1_name, contactor1_name=None,
+                       body2_name=None, contactor2_name=None,
                        distance_calculator='cadmbtb',
                        offset=0.0001):
         """
@@ -2291,8 +2288,10 @@ class Hdf5():
             pinter.attrs['type'] = 'permanent_interaction'
             pinter.attrs['body1_name'] = body1_name
             pinter.attrs['body2_name'] = body2_name
-            pinter.attrs['contactor1_name'] = contactor1_name
-            pinter.attrs['contactor2_name'] = contactor2_name
+            if contactor1_name is not None:
+                pinter.attrs['contactor1_name'] = contactor1_name
+            if contactor2_name is not None:
+                pinter.attrs['contactor2_name'] = contactor2_name
             pinter.attrs['distance_calculator'] = distance_calculator
             pinter.attrs['offset'] = offset
 

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -12,6 +12,7 @@ import numpy as np
 import h5py
 import bisect
 import time
+import pickle
 
 import tempfile
 from contextlib import contextmanager
@@ -991,113 +992,80 @@ class Hdf5():
                         velocity, contactors, mass, given_inertia, body_class,
                         shape_class, face_class, edge_class, number=None):
 
-        if mass is None or mass == 0.:
-            # a static object
-            body = None
-
-        else:
-
+        if mass > 0.:
             if body_class is None:
                 body_class = occ.OccBody
 
-            if given_inertia is not None:
-                inertia = given_inertia
-            else:
-                from OCC.GProp import GProp_GProps
-                from OCC.BRepGProp import brepgprop_VolumeProperties
-                from OCC.gp import gp_Ax1, gp_Dir
-
-                # compute mass and inertia from associated instances of Volume
-                volumes = filter(lambda s: isinstance(s, Volume),
-                                 contactors)
-
-                props = GProp_GProps()
-
-                for volume in volumes:
-
-                    iprops = GProp_GProps()
-                    ishape = occ.OccContactShape(
-                        self._shape.get(volume.data,
-                                        shape_class, face_class,
-                                        edge_class, new_instance=True)).data()
-
-                    # the shape relative displacement
-                    occ.occ_move(ishape, volume.translation)
-
-                    brepgprop_VolumeProperties(ishape, iprops)
-
-                    if volume.parameters is not None and \
-                       hasattr(volume.parameters, 'density'):
-                        density = volume.parameters.density
-                    else:
-                        density = 1
-
-                    props.Add(iprops, density)
-
-                # in props density=1
-                global_density = mass / props.Mass()
-                computed_com = props.Center_Of_Mass()
-
-                # center of mass shift
-                translation = np.subtract(translation,
-                                          [computed_com.Coord(1),
-                                           computed_com.Coord(2),
-                                           computed_com.Coord(3)])
-
-                I1 = global_density * props.MomentOfInertia(
-                    gp_Ax1(computed_com, gp_Dir(1, 0, 0)))
-                I2 = global_density * props.MomentOfInertia(
-                    gp_Ax1(computed_com, gp_Dir(0, 1, 0)))
-                I3 = global_density * props.MomentOfInertia(
-                    gp_Ax1(computed_com, gp_Dir(0, 0, 1)))
-
-                # computed_inertia = density * props.MatrixOfInertia()
-                inertia = [I1, I2, I3]
+            assert (given_inertia is not None)
+            inertia = given_inertia
 
             body = body_class(
-                translation + orientation, velocity, mass, inertia)
+                list(translation) + list(orientation), velocity, mass, inertia)
 
             if number is not None:
                 body.setNumber(number)
+        else:
+            # a static object
+            body = None
 
-            for rank, contactor in enumerate(contactors):
+        ctors_data = set([contactor.data for contactor in contactors])
 
-                contact_shape = None
-                reference_shape = occ.OccContactShape(
-                    self._shape.get(contactor.data,
-                                    shape_class, face_class,
-                                    edge_class, new_instance=True))
-                self._keep.append(reference_shape)
+        ref_shape = {ctor_data: occ.OccContactShape(
+            self._shape.get(ctor_data,
+                            shape_class, face_class,
+                            edge_class, new_instance=True))
+                     for ctor_data in ctors_data}
 
-                if hasattr(contactor, 'contact_type'):
+        ref_added = dict()
+        for contactor in contactors:
 
-                    if contactor.contact_type == 'Face':
-                        contact_shape = \
-                                    occ.OccContactFace(reference_shape,
-                                                       contactor.contact_index)
+            contact_shape = None
+            reference_shape = ref_shape[contactor.data]
 
-                    elif contactor.contact_type == 'Edge':
-                        contact_shape = \
-                                    occ.OccContactEdge(reference_shape,
-                                                       contactor.contact_index)
+            self._keep.append(reference_shape)
 
-                if contact_shape is not None:
+            if hasattr(contactor, 'contact_type'):
 
-                    if name not in self._occ_contactors:
-                        self._occ_contactors[name] = dict()
-                    self._occ_contactors[name][contactor.instance_name] = rank
+                if contactor.contact_type == 'Face':
+                    contact_shape = \
+                                occ.OccContactFace(reference_shape,
+                                                   contactor.contact_index)
 
+                elif contactor.contact_type == 'Edge':
+                    contact_shape = \
+                                occ.OccContactEdge(reference_shape,
+                                                   contactor.contact_index)
+
+            if contact_shape is not None:
+
+                if name not in self._occ_contactors:
+                    self._occ_contactors[name] = dict()
+
+                self._occ_contactors[name][contactor.instance_name] = \
+                                                        contact_shape
+
+                if body is not None:
                     body.addContactShape(contact_shape,
                                          contactor.translation,
                                          contactor.orientation,
                                          contactor.group)
-
                 else:
+                    occ.occ_move(contact_shape, list(contactor.translation) +\
+                                 list(contactor.orientation))
+
+            if reference_shape not in ref_added:
+                if body is not None:
                     body.addShape(reference_shape.shape(),
                                   contactor.translation,
                                   contactor.orientation)
+                else:
+                    occ.occ_move(reference_shape.shape(),
+                                 list(contactor.translation) +\
+                                 list(contactor.orientation))
+                ref_added[reference_shape] = True
 
-                self._set_external_forces(body)
+        if body is not None:
+            self._set_external_forces(body)
 
             # add the dynamical system to the non smooth
             # dynamical system
@@ -1507,8 +1475,8 @@ class Hdf5():
                 topology()
 
             pinter = self.permanent_interactions()[name]
-            body1_name=pinter.attrs['body1_name']
-            body2_name=pinter.attrs['body2_name']
+            body1_name = pinter.attrs['body1_name']
+            body2_name = pinter.attrs['body2_name']
 
             ds1 = occ.cast_OccBody(topo.getDynamicalSystem(body1_name))
             try:
@@ -1532,27 +1500,22 @@ class Hdf5():
             cg2 = int(ctr2.attrs['group'])
             nslaw = self._broadphase.nslaw(cg1, cg2)
 
-            if self.verbose:
-                print (body1_name, self._occ_contactors[body1_name])
-            cocs1_rank = self._occ_contactors[body1_name][contactor1_name]
-            cocs1 = ds1.contactShape(cocs1_rank)
+            cocs1 = self._occ_contactors[body1_name][contactor1_name]
+            cocs2 = self._occ_contactors[body2_name][contactor2_name]
 
-            if body2_name in self._occ_contactors:
-                cocs2_rank = self._occ_contactors[body2_name][contactor2_name]
-                cocs2 = ds2.contactShape(cocs2_rank)
-            else:
-                topods2 = self._shape.get(ctr2.attrs['name'])
-                self._keep.append(topods2)
-                ocs2 = occ.OccContactShape(topods2)
+            # else:
+            #     topods2 = self._shape.get(ctr2.attrs['name'])
+            #     self._keep.append(topods2)
+            #     ocs2 = occ.OccContactShape(topods2)
 
-                index2 = int(ctr2.attrs['contact_index'])
+            #     index2 = int(ctr2.attrs['contact_index'])
 
-                ctact_t2 = ctr2.attrs['type']
+            #     ctact_t2 = ctr2.attrs['type']
 
-                ctactbuild = {'Face': occ.OccContactFace,
-                              'Edge': occ.OccContactEdge}
+            #     ctactbuild = {'Face': occ.OccContactFace,
+            #                   'Edge': occ.OccContactEdge}
 
-                cocs2 = ctactbuild[ctact_t2](ocs2, index2)
+            #     cocs2 = ctactbuild[ctact_t2](ocs2, index2)
 
             cp1 = occ.ContactPoint(cocs1)
             cp2 = occ.ContactPoint(cocs2)
@@ -1741,11 +1704,79 @@ class Hdf5():
                             velocities[id_vlast, 1] ==
                             self.instances()[name].attrs['id'])[0]
                         xvel = velocities[id_vlast[id_vlast_inst[0]], :]
-                        velocity = (xvel[2], xvel[3], xvel[4],
-                                    xvel[5], xvel[6], xvel[7])
-                        self.importObject(name, body_class, shape_class,
-                                          face_class, edge_class,
-                                          translation, orientation, velocities)
+                        velocity = (xvel[2], xvel[3], xvel[4], xvel[5], xvel[6], xvel[7])
+
+                    # start from initial conditions
+                    else:
+                        print ('Import  dynamic or static object number ', obj.attrs['id'], 'from initial state')
+                        print ('                object name   ', name)
+                        translation = obj.attrs['translation']
+                        orientation = obj.attrs['orientation']
+                        velocity = obj.attrs['velocity']
+
+                    # bodyframe center of mass
+                    center_of_mass = None
+
+                    # bodyframe center of mass
+                    # check for compatibility
+                    if 'center_of_mass' in obj.attrs:
+                        center_of_mass = \
+                                obj.attrs['center_of_mass'].astype(float)
+                    else:
+                        center_of_mass = [0, 0, 0]
+
+                    input_ctrs = [ctr for _n_, ctr in obj.items()]
+
+                    contactors = []
+                    occ_type = False
+                    for ctr in input_ctrs:
+                        if 'type' in ctr.attrs:
+                            # occ contact
+                            occ_type = True
+                            contactors.append(
+                                Contactor(
+                                    instance_name=ctr.attrs['instance_name'],
+                                    shape_data=ctr.attrs['name'],
+                                    collision_group=ctr.attrs['group'].astype(int),
+                                    contact_type=ctr.attrs['type'],
+                                    contact_index=ctr.attrs['contact_index'].astype(int),
+                                    relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
+                                    relative_orientation=ctr.attrs['orientation'].astype(float)))
+                        elif 'group' in ctr.attrs:
+                            # bullet contact
+                            assert not occ_type
+                            contactors.append(
+                                Contactor(
+                                    instance_name=ctr.attrs['instance_name'],
+                                    shape_data=ctr.attrs['name'],
+                                    collision_group=ctr.attrs['group'].astype(int),
+                                    relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
+                                    relative_orientation=ctr.attrs['orientation'].astype(float)))
+                        else:
+                            # occ shape
+                            occ_type = True
+                            # fix: not only contactors here
+                            contactors.append(
+                                Volume(
+                                    instance_name=ctr.attrs['instance_name'],
+                                    shape_data=ctr.attrs['name'],
+                                    parameters=pickle.loads(ctr.attrs['parameters']),
+                                    relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
+                                    relative_orientation=ctr.attrs['orientation'].astype(float)))
+
+                    if 'inertia' in obj.attrs:
+                        inertia = obj.attrs['inertia']
+                    else:
+                        inertia = None
+
+                    if occ_type:
+                        # Occ object
+                        self.importOccObject(
+                            name, floatv(translation), floatv(orientation),
+                            floatv(velocity), contactors, float(mass),
+                            inertia, body_class, shape_class, face_class,
+                            edge_class,
+                            number = self.instances()[name].attrs['id'])
                     else:
                         # start from initial conditions
                         self.importObject(name, body_class, shape_class,
@@ -2255,6 +2286,66 @@ class Hdf5():
 
         if name not in self._input:
 
+            com_translation = [0., 0., 0.]
+
+            if inertia is None and mass > 0.:
+                volumes = filter(lambda s: isinstance(s, Volume),
+                                 shapes)
+                if len(volumes) > 0:
+                    # a computed inertia and center of mass
+                    # occ only
+                    from OCC.GProp import GProp_GProps
+                    from OCC.BRepGProp import brepgprop_VolumeProperties
+                    from OCC.gp import gp_Ax1, gp_Dir
+                    volumes = filter(lambda s: isinstance(s, Volume),
+                                     shapes)
+
+                    props = GProp_GProps()
+
+                    for volume in volumes:
+
+                        iprops = GProp_GProps()
+                        iishape = self._shape.get(volume.data,
+                                                  shape_class=None, face_class=None,
+                                                  edge_class=None, new_instance=True)
+                        ishape = occ.OccContactShape(iishape).data()
+
+                        # the shape relative displacement
+                        occ.occ_move(ishape, list(volume.translation) +\
+                                     list(volume.orientation))
+
+                        brepgprop_VolumeProperties(iishape, iprops)
+
+                        if volume.parameters is not None and \
+                           hasattr(volume.parameters, 'density'):
+                            density = volume.parameters.density
+                        else:
+                            density = 1
+
+                        props.Add(iprops, density)
+
+                    assert (props.Mass() > 0.)
+                    global_density = mass / props.Mass()
+                    computed_com = props.CentreOfMass()
+                    I1 = global_density * props.MomentOfInertia(
+                        gp_Ax1(computed_com, gp_Dir(1, 0, 0)))
+                    I2 = global_density * props.MomentOfInertia(
+                        gp_Ax1(computed_com, gp_Dir(0, 1, 0)))
+                    I3 = global_density * props.MomentOfInertia(
+                        gp_Ax1(computed_com, gp_Dir(0, 0, 1)))
+
+                    inertia = [I1, I2, I3]
+                    center_of_mass = np.array([computed_com.Coord(1),
+                                               computed_com.Coord(2),
+                                               computed_com.Coord(3)])
+
+                    print('computed inertia:', I1, I2, I3)
+                    print('computed center of mass:',
+                          computed_com.Coord(1),
+                          computed_com.Coord(2),
+                          computed_com.Coord(3))
+
+
             obj=group(self._input, name)
 
             if time_of_birth >= 0:
@@ -2267,6 +2358,7 @@ class Hdf5():
             obj.attrs['orientation']=ori
             obj.attrs['velocity']=velocity
             obj.attrs['center_of_mass']=center_of_mass
+
             if inertia is not None:
                 obj.attrs['inertia']=inertia
             if allow_self_collide is not None:
@@ -2293,7 +2385,7 @@ class Hdf5():
 
                 if hasattr(ctor, 'parameters') and \
                         ctor.parameters is not None:
-                    dat.attrs['parameters'] = ctor.parameters
+                    dat.attrs['parameters'] = pickle.dumps(ctor.parameters)
 
                 if hasattr(ctor, 'contact_type') and \
                    ctor.contact_type is not None:

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -306,6 +306,29 @@ def add_line(dataset, line):
     dataset[dataset.shape[0] - 1, :] = line
 
 
+
+#
+# misc fixes
+#
+# fix ctr.'name' in old hdf5 files
+#
+
+def upgrade_io_format(filename):
+
+    with Hdf5(filename, mode='a') as io:
+    
+        for instance_name in io.instances():
+            for contactor_instance_name in io.instances()[instance_name]:
+                contactor = io.instances()[instance_name][
+                    contactor_instance_name]
+                if 'name' in contactor.attrs:
+                    warn("""
+contactor {0} attribute 'name': renamed in 'shape_name'
+                    """)
+                    contactor.attrs['shape_name'] = contactor['name']
+                    del contactor['name']
+
+    
 def str_of_file(filename):
     with open(filename, 'r') as f:
         return str(f.read())
@@ -918,6 +941,7 @@ class Hdf5():
         self._solv_data = data(self._data, 'solv', 4,
                                use_compression = self._use_compression)
         self._input = group(self._data, 'input')
+
         self._nslaws_data = group(self._data, 'nslaws')
 
         if self._shape_filename is None:
@@ -1065,7 +1089,7 @@ class Hdf5():
             # a static object
             body = None
 
-        ctors_data = set([contactor.data for contactor in contactors])
+        ctors_data = set([contactor.shape_name for contactor in contactors])
 
         ref_shape = {ctor_data: occ.OccContactShape(
             self._shape.get(ctor_data,
@@ -1077,7 +1101,7 @@ class Hdf5():
         for contactor in contactors:
 
             contact_shape = None
-            reference_shape = ref_shape[contactor.data]
+            reference_shape = ref_shape[contactor.shape_name]
 
             self._keep.append(reference_shape)
 
@@ -1147,11 +1171,11 @@ class Hdf5():
                 cset = SiconosContactorSet()
                 csetpos = (translation + orientation)
                 for c in contactors:
-                    shp = self._shape.get(c.data)
+                    shp = self._shape.get(c.shape_name)
                     pos = list(c.translation) + list(c.orientation)
                     cset.append(SiconosContactor(shp, pos, c.group))
                     if self.verbose:
-                        print('Adding shape %s to static contactor'%c.data, pos)
+                        print('Adding shape %s to static contactor'%c.shape_name, pos)
                 self._broadphase.insertStaticContactorSet(cset, csetpos)
 
                 self._static[name] = {
@@ -1202,7 +1226,7 @@ class Hdf5():
                         btCollisionObject.CF_STATIC_OBJECT)
 
                     static_cobj.setCollisionShape(
-                        self._shape.get(c.data))
+                        self._shape.get(c.shape_name))
 
                     self._static[name] = {
                         'number': number,
@@ -1238,7 +1262,7 @@ class Hdf5():
 
                 cset = SiconosContactorSet()
                 for c in contactors:
-                    shp = self._shape.get(c.data)
+                    shp = self._shape.get(c.shape_name)
                     pos = list(c.translation) + list(c.orientation)
                     cset.append(SiconosContactor(shp, pos, c.group))
 
@@ -1247,7 +1271,7 @@ class Hdf5():
             elif use_original and use_bullet:
                 # a Bullet moving object
                 bws = BulletWeightedShape(
-                    self._shape.get(contactors[0].data), mass)
+                    self._shape.get(contactors[0].shape_name), mass)
 
                 if inertia is not None:
 
@@ -1267,9 +1291,9 @@ class Hdf5():
 
                 #body.setNullifyFGyr(True)
                 for contactor in contactors[1:]:
-                    shape_id = self._shapeid[contactor.data]
+                    shape_id = self._shapeid[contactor.shape_name]
 
-                    body.addCollisionShape(self._shape.get(contactor.data),
+                    body.addCollisionShape(self._shape.get(contactor.shape_name),
                                            contactor.translation,
                                            contactor.orientation,
                                            contactor.group)
@@ -1635,13 +1659,14 @@ class Hdf5():
         contactors = []
         occ_type = False
         for ctr in input_ctrs:
+
             if 'type' in ctr.attrs:
                 # occ contact
                 occ_type = True
                 contactors.append(
                     Contactor(
                         instance_name=ctr.attrs['instance_name'],
-                        shape_data=ctr.attrs['name'],
+                        shape_name=ctr.attrs['shape_name'],
                         collision_group=ctr.attrs['group'].astype(int),
                         contact_type=ctr.attrs['type'],
                         contact_index=ctr.attrs['contact_index'].astype(int),
@@ -1653,7 +1678,7 @@ class Hdf5():
                 contactors.append(
                     Contactor(
                         instance_name=ctr.attrs['instance_name'],
-                        shape_data=ctr.attrs['name'],
+                        shape_name=ctr.attrs['shape_name'],
                         collision_group=ctr.attrs['group'].astype(int),
                         relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
                         relative_orientation=ctr.attrs['orientation'].astype(float)))
@@ -1664,7 +1689,7 @@ class Hdf5():
                 contactors.append(
                     Shape(
                         instance_name=ctr.attrs['instance_name'],
-                        shape_data=ctr.attrs['name'],
+                        shape_name=ctr.attrs['shape_name'],
                         relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
                         relative_orientation=ctr.attrs['orientation'].astype(float)))
 
@@ -1802,7 +1827,7 @@ class Hdf5():
                             contactors.append(
                                 Contactor(
                                     instance_name=ctr.attrs['instance_name'],
-                                    shape_data=ctr.attrs['name'],
+                                    shape_name=ctr.attrs['shape_name'],
                                     collision_group=ctr.attrs['group'].astype(int),
                                     contact_type=ctr.attrs['type'],
                                     contact_index=ctr.attrs['contact_index'].astype(int),
@@ -1814,7 +1839,7 @@ class Hdf5():
                             contactors.append(
                                 Contactor(
                                     instance_name=ctr.attrs['instance_name'],
-                                    shape_data=ctr.attrs['name'],
+                                    shape_name=ctr.attrs['shape_name'],
                                     collision_group=ctr.attrs['group'].astype(int),
                                     relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
                                     relative_orientation=ctr.attrs['orientation'].astype(float)))
@@ -1826,7 +1851,7 @@ class Hdf5():
                                 contactors.append(
                                     Volume(
                                         instance_name=ctr.attrs['instance_name'],
-                                        shape_data=ctr.attrs['name'],
+                                        shape_name=ctr.attrs['shape_name'],
                                         parameters=pickle.loads(ctr.attrs['parameters']),
                                         relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
                                         relative_orientation=ctr.attrs['orientation'].astype(float)))
@@ -1834,7 +1859,7 @@ class Hdf5():
                                 contactors.append(
                                     Shape(
                                         instance_name=ctr.attrs['instance_name'],
-                                        shape_data=ctr.attrs['name'],
+                                        shape_name=ctr.attrs['shape_name'],
                                         relative_translation=np.subtract(ctr.attrs['translation'].astype(float), center_of_mass),
                                         relative_orientation=ctr.attrs['orientation'].astype(float)))
 
@@ -1855,7 +1880,7 @@ class Hdf5():
                         # Bullet object
                         self.importBulletObject(
                             name, floatv(translation), floatv(orientation),
-                            floatv(velocity), contactors, float(mass),
+                            floatv(velocity), contactors, mass,
                             inertia, body_class, shape_class,
                             number = self.instances()[name].attrs['id'])
 
@@ -2467,7 +2492,7 @@ class Hdf5():
                     for volume in volumes:
 
                         iprops = GProp_GProps()
-                        iishape = self._shape.get(volume.data,
+                        iishape = self._shape.get(volume.shape_name,
                                                   shape_class=None, face_class=None,
                                                   edge_class=None, new_instance=True)
                         ishape = occ.OccContactShape(iishape).data()
@@ -2535,13 +2560,13 @@ class Hdf5():
                     instance_name = ctor.instance_name
                 else:
                     # the default name for contactor
-                    instance_name = '{0}-{1}'.format(ctor.data, num)
+                    instance_name = '{0}-{1}'.format(ctor.shape_name, num)
 
                 dat = data(obj, instance_name, 0,
                            use_compression=self._use_compression)
 
                 dat.attrs['instance_name'] = instance_name
-                dat.attrs['name'] = ctor.data
+                dat.attrs['shape_name'] = ctor.shape_name
                 if hasattr(ctor, 'group'):
                     dat.attrs['group'] = ctor.group
 

--- a/io/swig/io/mechanics_io.py
+++ b/io/swig/io/mechanics_io.py
@@ -514,14 +514,20 @@ def occ_load_file(filename):
     return comp
 
 
-def topods_shape_reader(shape):
+def topods_shape_reader(shape, deflection=0.001):
 
     from OCC.StlAPI import StlAPI_Writer
+    from OCC.BRepMesh import BRepMesh_IncrementalMesh
+
     import vtk
 
     stl_writer = StlAPI_Writer()
 
-    with tmpfile(debug=True, suffix='.stl') as tmpf:
+    with tmpfile(suffix='.stl') as tmpf:
+        mesh = BRepMesh_IncrementalMesh(shape, deflection)
+        mesh.Perform()
+        assert mesh.IsDone()
+        stl_writer.SetASCIIMode(False)
         stl_writer.Write(shape, tmpf[1])
         tmpf[0].flush()
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -986,10 +986,10 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
             if 'type' in contactor.attrs:
                 contact_type = contactor.attrs['type']
                 contact_index = contactor.attrs['contact_index']
-                contact_shape_indx = (contact_type, contactor.attrs['name'],
+                contact_shape_indx = (contact_type, contactor.attrs['shape_name'],
                                       contact_index)
             else:
-                contact_shape_indx = contactor.attrs['name']
+                contact_shape_indx = contactor.attrs['shape_name']
 
             contactors[instance].append(contact_shape_indx)
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -189,90 +189,99 @@ contactors = dict()
 offsets = dict()
 
 
-def step_reader(step_string):
+def occ_topo_list(shape):
+    """ return the edges & faces from `shape`
 
-    from OCC.StlAPI import StlAPI_Writer
+    :param shape: a TopoDS_Shape
+    :return: a list of edges and faces
+    """
+
+    from OCC.TopAbs import TopAbs_FACE
+    from OCC.TopAbs import TopAbs_EDGE
+    from OCC.TopExp import TopExp_Explorer
+    from OCC.TopoDS import topods_Face, topods_Edge
+    
+
+    topExp = TopExp_Explorer()
+    topExp.Init(shape, TopAbs_FACE)
+    faces = []
+    edges = []
+    
+    while topExp.More():
+        face = topods_Face(topExp.Current())
+        faces.append(face)
+        topExp.Next()
+
+    topExp.Init(shape, TopAbs_EDGE)
+
+    while topExp.More():
+        edge = topods_Edge(topExp.Current())
+        edges.append(edge)
+        topExp.Next()
+
+    return faces, edges
+
+
+def occ_load_file(filename):
+    """
+    load in pythonocc a igs or step file
+
+    :param filename: a filename with extension
+    :return: a topods_shape
+    """
+
     from OCC.STEPControl import STEPControl_Reader
-    from OCC.BRep import BRep_Builder
-    from OCC.TopoDS import TopoDS_Compound
-    from OCC.IFSelect import IFSelect_RetDone, IFSelect_ItemsByEntity
-
-    builder = BRep_Builder()
-    comp = TopoDS_Compound()
-    builder.MakeCompound(comp)
-
-    stl_writer = StlAPI_Writer()
-    stl_writer.SetASCIIMode(True)
-
-    with io_tmpfile(contents=io.shapes()[shape_name][:][0]) as tmpfile:
-        step_reader = STEPControl_Reader()
-
-        status = step_reader.ReadFile(tmpfile[1])
-
-        if status == IFSelect_RetDone:  # check status
-            failsonly = False
-            step_reader.PrintCheckLoad(failsonly, IFSelect_ItemsByEntity)
-            step_reader.PrintCheckTransfer(failsonly, IFSelect_ItemsByEntity)
-            ok = step_reader.TransferRoot(1)
-            nbs = step_reader.NbShapes()
-
-            for i in range(1, nbs + 1):
-                shape = step_reader.Shape(i)
-
-                builder.Add(comp, shape)
-
-            with io_tmpfile(suffix='.stl') as tmpf:
-                    stl_writer.Write(comp, tmpf[1])
-                    tmpf[0].flush()
-
-                    reader = vtk.vtkSTLReader()
-                    reader.SetFileName(tmpf[1])
-                    reader.Update()
-
-                    return reader
-
-
-def iges_reader(iges_string):
-
-    from OCC.StlAPI import StlAPI_Writer
     from OCC.IGESControl import IGESControl_Reader
     from OCC.BRep import BRep_Builder
     from OCC.TopoDS import TopoDS_Compound
-    from OCC.IFSelect import IFSelect_RetDone, IFSelect_ItemsByEntity
+    from OCC.IFSelect import IFSelect_RetDone,\
+    IFSelect_ItemsByEntity
 
+    reader_switch = {'stp': STEPControl_Reader,
+                     'step': STEPControl_Reader,
+                     'igs': IGESControl_Reader,
+                     'iges': IGESControl_Reader}
+    
     builder = BRep_Builder()
     comp = TopoDS_Compound()
     builder.MakeCompound(comp)
 
+    reader = reader_switch[os.path.splitext(filename)[1][1:].lower()]()
+        
+    status = reader.ReadFile(filename)
+        
+    if status == IFSelect_RetDone:  # check status
+        failsonly = False
+        reader.PrintCheckLoad(
+            failsonly, IFSelect_ItemsByEntity)
+        reader.PrintCheckTransfer(
+            failsonly, IFSelect_ItemsByEntity)
+        
+        ok = reader.TransferRoots()
+        nbs = reader.NbShapes()
+
+        for i in range(1, nbs + 1):
+            shape = reader.Shape(i)
+            builder.Add(comp, shape)
+
+    return comp
+
+
+def topods_shape_reader(shape):
+
+    from OCC.StlAPI import StlAPI_Writer
+
     stl_writer = StlAPI_Writer()
-    stl_writer.SetASCIIMode(True)
 
-    with io_tmpfile(contents=io.shapes()[shape_name][:][0]) as tmpfile:
-        iges_reader = IGESControl_Reader()
+    with io_tmpfile(debug=True, suffix='.stl') as tmpf:
+        stl_writer.Write(shape, tmpf[1])
+        tmpf[0].flush()
 
-        status = iges_reader.ReadFile(tmpfile[1])
+        reader = vtk.vtkSTLReader()
+        reader.SetFileName(tmpf[1])
+        reader.Update()
 
-        if status == IFSelect_RetDone:  # check status
-            failsonly = False
-            iges_reader.PrintCheckLoad(failsonly, IFSelect_ItemsByEntity)
-            iges_reader.PrintCheckTransfer(failsonly, IFSelect_ItemsByEntity)
-            ok = iges_reader.TransferRoots()
-            nbs = iges_reader.NbShapes()
-
-            for i in range(1, nbs + 1):
-                shape = iges_reader.Shape(i)
-
-                builder.Add(comp, shape)
-
-            with io_tmpfile(suffix='.stl') as tmpf:
-                    stl_writer.Write(comp, tmpf[1])
-                    tmpf[0].flush()
-
-                    reader = vtk.vtkSTLReader()
-                    reader.SetFileName(tmpf[1])
-                    reader.Update()
-
-                    return reader
+        return reader
 
 
 def brep_reader(brep_string, indx):
@@ -796,24 +805,40 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
                 mappers[shape_name] = (
                     x for x in [mappers[associated_shape]()])
 
-            elif shape_type in ['stp', 'step']:
-                reader = step_reader(str(io.shapes()[shape_name][:]))
+            elif shape_type in ['stp', 'step', 'igs', 'iges']:
+                with io_tmpfile(
+                        debug=True,
+                        suffix='.{0}'.format(shape_type),
+                        contents=str(io.shapes()[shape_name][:][0])) as tmpf:
+                    shape = occ_load_file(tmpf[1])
 
-                readers[shape_name] = reader
-                mapper = vtk.vtkDataSetMapper()
-                add_compatiblity_methods(mapper)
-                mapper.SetInputConnection(reader.GetOutputPort())
-                mappers[shape_name] = (x for x in [mapper])
-            else:
-                assert shape_type in ['igs', 'iges']
+                    # whole shape
+                    reader = topods_shape_reader(shape)
+                    readers[shape_name] = reader
+                    mapper = vtk.vtkDataSetMapper()
+                    add_compatiblity_methods(mapper)
+                    mapper.SetInputConnection(reader.GetOutputPort())
+                    mappers[shape_name] = (x for x in [mapper])
 
-                reader = iges_reader(str(io.shapes()[shape_name][:]))
+                    # subparts
+                    faces, edges = occ_topo_list(shape)
+                    for i, f in enumerate(faces):
+                        shape_indx = ('Face', shape_name, i)
+                        reader = topods_shape_reader(f)
+                        readers[shape_indx] = reader
+                        mapper = vtk.vtkDataSetMapper()
+                        add_compatiblity_methods(mapper)
+                        mapper.SetInputConnection(reader.GetOutputPort())
+                        mappers[shape_indx] = (x for x in [mapper])
 
-                readers[shape_name] = reader
-                mapper = vtk.vtkDataSetMapper()
-                add_compatiblity_methods(mapper)
-                mapper.SetInputConnection(reader.GetOutputPort())
-                mappers[shape_name] = (x for x in [mapper])
+                    for i, e in enumerate(edges):
+                        shape_indx = ('Edge', shape_name, i)
+                        reader = topods_shape_reader(e)
+                        readers[shape_indx] = reader
+                        mapper = vtk.vtkDataSetMapper()
+                        add_compatiblity_methods(mapper)
+                        mapper.SetInputConnection(reader.GetOutputPort())
+                        mappers[shape_indx] = (x for x in [mapper])
 
         elif shape_type == 'heightmap':
             points = vtk.vtkPoints()
@@ -933,10 +958,12 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
             mapper.SetInputConnection(source.GetOutputPort())
             mappers[shape_name] = (x for x in [mapper])
 
-    fixed_mappers = dict()
-    for shape_name in io.shapes():
-        if shape_name not in fixed_mappers:
-            fixed_mappers[shape_name] = mappers[shape_name].next()
+    unfrozen_mappers = dict()
+
+    for shape_name in mappers.keys():
+        if shape_name not in unfrozen_mappers:
+            print (shape_name)
+            unfrozen_mappers[shape_name] = mappers[shape_name].next()
 
     for instance_name in io.instances():
 
@@ -953,9 +980,18 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
             static_actors[instance] = list()
 
         for contactor_instance_name in io.instances()[instance_name]:
-            contactor_shape_name = io.instances()[instance_name][
-                contactor_instance_name].attrs['name']
-            contactors[instance].append(contactor_shape_name)
+            contactor = io.instances()[instance_name][contactor_instance_name]
+            contact_shape_indx = None
+            print instance_name, (contactor.attrs.keys())
+            if 'type' in contactor.attrs:
+                contact_type = contactor.attrs['type']
+                contact_index = contactor.attrs['contact_index']
+                contact_shape_indx = (contact_type, contactor.attrs['name'],
+                                      contact_index)
+            else:
+                contact_shape_indx = contactor.attrs['name']
+
+            contactors[instance].append(contact_shape_indx)
 
             actor = vtk.vtkActor()
             if io.instances()[instance_name].attrs.get('mass', 0) > 0:
@@ -972,21 +1008,26 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
                     config.get('static_opacity', 1.0))
 
             actor.GetProperty().SetColor(random_color())
-            actor.SetMapper(fixed_mappers[contactor_shape_name])
+            actor.SetMapper(unfrozen_mappers[contact_shape_indx])
 
             renderer.AddActor(actor)
 
             transform = vtk.vtkTransform()
             transformer = vtk.vtkTransformFilter()
 
-            if contactor_shape_name in readers:
+            if contact_shape_indx in readers:
                 transformer.SetInputConnection(
-                    readers[contactor_shape_name].GetOutputPort())
+                    readers[contact_shape_indx].GetOutputPort())
             else:
-                transformer.SetInputData(datasets[contactor_shape_name])
+                transformer.SetInputData(datasets[contact_shape_indx])
 
-            if 'scale' in io.shapes()[contactor_shape_name].attrs:
-                scale = io.shapes()[contactor_shape_name].attrs['scale']
+            if isinstance(contact_shape_indx, tuple):
+                contact_shape_name = contact_shape_indx[1]
+            else:
+                contact_shape_name = contact_shape_indx
+                
+            if 'scale' in io.shapes()[contact_shape_name].attrs:
+                scale = io.shapes()[contact_shape_name].attrs['scale']
                 scale_transform = vtk.vtkTransform()
                 scale_transform.Scale(scale, scale, scale)
                 scale_transform.SetInput(transform)
@@ -996,7 +1037,7 @@ with Hdf5(io_filename=io_filename, mode='r') as io:
                 transformer.SetTransform(transform)
                 actor.SetUserTransform(transform)
 
-            transformers[contactor_shape_name] = transformer
+            transformers[contact_shape_indx] = transformer
 
             big_data_source.AddInputConnection(transformer.GetOutputPort())
 

--- a/kernel/src/simulationTools/TimeStepping.cpp
+++ b/kernel/src/simulationTools/TimeStepping.cpp
@@ -441,6 +441,9 @@ void TimeStepping::advanceToEvent()
     indexSet0->bundle(*ui)->resetAllLambda();
   }
   newtonSolve(_newtonTolerance, _newtonMaxIteration);
+
+  updateWorldFromDS();
+  updateInteractions();
 }
 
 /*update of the nabla */

--- a/kernel/src/simulationTools/TimeStepping.cpp
+++ b/kernel/src/simulationTools/TimeStepping.cpp
@@ -441,9 +441,6 @@ void TimeStepping::advanceToEvent()
     indexSet0->bundle(*ui)->resetAllLambda();
   }
   newtonSolve(_newtonTolerance, _newtonMaxIteration);
-
-  updateWorldFromDS();
-  updateInteractions();
 }
 
 /*update of the nabla */

--- a/kernel/swig/kernel.i
+++ b/kernel/swig/kernel.i
@@ -233,9 +233,10 @@ typedef __mpz_struct mpz_t[1];
 %include "SiconosAlgebraTypeDef.hpp"
 %include "SiconosAlgebra.hpp"
 
-%include "SimulationGraphs.hpp"
-
 %import "RelationNamespace.hpp";
+
+
+
 
 %inline
 %{

--- a/kernel/swig/kernel.i
+++ b/kernel/swig/kernel.i
@@ -276,6 +276,16 @@ typedef __mpz_struct mpz_t[1];
     return std11::dynamic_pointer_cast<NewtonImpactNSL>(nslaw);
   }
 
+  SP::NewtonEulerDS cast_NewtonEulerDS(SP::DynamicalSystem ds)
+  {
+    return std11::dynamic_pointer_cast<NewtonEulerDS>(ds);
+  }
+
+  SP::LagrangianDS cast_LagrangianDS(SP::DynamicalSystem ds)
+  {
+    return std11::dynamic_pointer_cast<LagrangianDS>(ds);
+  }
+
 %}
 
 //namespace std {

--- a/kernel/swig/kernel.i
+++ b/kernel/swig/kernel.i
@@ -233,10 +233,9 @@ typedef __mpz_struct mpz_t[1];
 %include "SiconosAlgebraTypeDef.hpp"
 %include "SiconosAlgebra.hpp"
 
+%include "SimulationGraphs.hpp"
+
 %import "RelationNamespace.hpp";
-
-
-
 
 %inline
 %{

--- a/kernel/swig/kernel.i
+++ b/kernel/swig/kernel.i
@@ -238,6 +238,55 @@ typedef __mpz_struct mpz_t[1];
 
 
 
+
+
+//namespace std {
+
+  %template (dspv) std::vector<std::pair<std11::shared_ptr<DynamicalSystem>,
+                                         std11::shared_ptr<DynamicalSystem> > >;
+
+  %template (dsiv) std::vector<std::pair<unsigned int, unsigned int > >;
+
+
+  %template (dsi) std::pair<unsigned int, unsigned int >;
+
+  %template (dsp) std::pair<std11::shared_ptr<DynamicalSystem>,
+                            std11::shared_ptr<DynamicalSystem> >;
+
+//BouncingBallNETS.py, attempt to reach DSlink as a vector...
+//swig failure.
+//%shared_ptr(VectorOfBlockVectors);
+//%template (vectorOfBlockVectors) std::vector<std11::shared_ptr<BlockVector> >;
+///
+//}
+
+
+%template(unsignedintv) std11::shared_ptr<std::vector<unsigned int> >;
+
+// not sufficient
+%ignore Question<bool>;
+%template (qbool) Question<bool>;
+
+%ignore Question<unsigned int>;
+%template (quint) Question<unsigned int>;
+
+
+%ignore OSNSMatrix::updateSizeAndPositions;
+
+// registered classes in KernelRegistration.i
+
+%include KernelRegistration.i
+%include pyRegister.i
+KERNEL_REGISTRATION();
+
+%include pyInclude.i
+
+KERNEL_REGISTRATION()
+
+%fragment("StdSequenceTraits");
+
+%fragment("StdMapTraits");
+
 %inline
 %{
 
@@ -287,52 +336,3 @@ typedef __mpz_struct mpz_t[1];
   }
 
 %}
-
-//namespace std {
-
-  %template (dspv) std::vector<std::pair<std11::shared_ptr<DynamicalSystem>,
-                                         std11::shared_ptr<DynamicalSystem> > >;
-
-  %template (dsiv) std::vector<std::pair<unsigned int, unsigned int > >;
-
-
-  %template (dsi) std::pair<unsigned int, unsigned int >;
-
-  %template (dsp) std::pair<std11::shared_ptr<DynamicalSystem>,
-                            std11::shared_ptr<DynamicalSystem> >;
-
-//BouncingBallNETS.py, attempt to reach DSlink as a vector...
-//swig failure.
-//%shared_ptr(VectorOfBlockVectors);
-//%template (vectorOfBlockVectors) std::vector<std11::shared_ptr<BlockVector> >;
-///
-//}
-
-
-%template(unsignedintv) std11::shared_ptr<std::vector<unsigned int> >;
-
-// not sufficient
-%ignore Question<bool>;
-%template (qbool) Question<bool>;
-
-%ignore Question<unsigned int>;
-%template (quint) Question<unsigned int>;
-
-
-%ignore OSNSMatrix::updateSizeAndPositions;
-
-// registered classes in KernelRegistration.i
-
-%include KernelRegistration.i
-%include pyRegister.i
-KERNEL_REGISTRATION();
-
-%include pyInclude.i
-
-KERNEL_REGISTRATION()
-
-%fragment("StdSequenceTraits");
-
-%fragment("StdMapTraits");
-
-

--- a/mechanics/src/occ/OccContactEdge.cpp
+++ b/mechanics/src/occ/OccContactEdge.cpp
@@ -28,14 +28,18 @@ const SPC::TopoDS_Edge OccContactEdge::contact() const
 
 void OccContactEdge::computeUVBounds()
 {
-  TopExp_Explorer Ex1;
-  Ex1.Init(*this->contact(),TopAbs_EDGE);
-  const TopoDS_Edge& edge = TopoDS::Edge(Ex1.Current());
-  BRepAdaptor_Curve SC(edge);
-  this->binf1[0]=SC.FirstParameter();
-  this->bsup1[0]=SC.LastParameter();
-  this->binf1[1]=0.;
-  this->bsup1[1]=0.;
+  TopExp_Explorer exp;
+  exp.Init(this->data(),TopAbs_EDGE);
+  for (unsigned int i=0; i<_index; ++i, exp.Next());
+  if (exp.More())
+  {
+    const TopoDS_Edge& edge = TopoDS::Edge(exp.Current());
+    BRepAdaptor_Curve SC(edge);
+    this->binf1[0]=SC.FirstParameter();
+    this->bsup1[0]=SC.LastParameter();
+    this->binf1[1]=0.;
+    this->bsup1[1]=0.;
+  }
 }
 
 

--- a/mechanics/src/occ/OccContactFace.cpp
+++ b/mechanics/src/occ/OccContactFace.cpp
@@ -27,10 +27,18 @@ SPC::TopoDS_Face OccContactFace::contact() const
 
 void OccContactFace::computeUVBounds()
 {
-  BRepTools::UVBounds(*this->_face,
-                      this->binf1[0],
-                      this->bsup1[0],
-                      this->binf1[1],
-                      this->bsup1[1]);
+
+  TopExp_Explorer exp;
+  exp.Init(this->data(), TopAbs_FACE);
+  for (unsigned int i=0; i<_index; ++i, exp.Next());
+  if (exp.More())
+  {
+    const TopoDS_Face& face = TopoDS::Face(exp.Current());
+    BRepTools::UVBounds(face,
+                        this->binf1[0],
+                        this->bsup1[0],
+                        this->binf1[1],
+                        this->bsup1[1]);
+  }
 }
 

--- a/mechanics/src/occ/OccR.cpp
+++ b/mechanics/src/occ/OccR.cpp
@@ -15,8 +15,8 @@ OccR::OccR(const ContactPoint& contact1,
   _contact1(contact1),
   _contact2(contact2),
   _geometer(),
-  _normalFromFace1(true),
-  _offsetp1(true),
+  _normalFromFace1(false),
+  _offsetp1(false),
   _offset(0.1)
 {
   switch (Type::value(distance_calculator))
@@ -40,10 +40,10 @@ void OccR::computeh(double time, BlockVector& q0, SiconosVector& y)
 
   ContactShapeDistance& dist = this->_geometer->answer;
 
-  // printf("---->%g P1=(%g, %g, %g) P2=(%g,%g,%g) N=(%g, %g, %g)\n", dist.value,
-  //        dist.x1, dist.y1, dist.z1,
-  //        dist.x2, dist.y2, dist.z2,
-  //        dist.nx, dist.ny, dist.nz);
+  printf("---->%g P1=(%g, %g, %g) P2=(%g,%g,%g) N=(%g, %g, %g)\n", dist.value,
+          dist.x1, dist.y1, dist.z1,
+          dist.x2, dist.y2, dist.z2,
+          dist.nx, dist.ny, dist.nz);
 
   double& X1 = dist.x1;
   double& Y1 = dist.y1;

--- a/mechanics/src/occ/OccR.cpp
+++ b/mechanics/src/occ/OccR.cpp
@@ -8,6 +8,9 @@
 #include <iostream>
 #include <boost/typeof/typeof.hpp>
 
+#undef DEBUG_MESSAGES
+#include "debug.h"
+
 OccR::OccR(const ContactPoint& contact1,
            const ContactPoint& contact2,
            const DistanceCalculatorType& distance_calculator) :
@@ -40,10 +43,10 @@ void OccR::computeh(double time, BlockVector& q0, SiconosVector& y)
 
   ContactShapeDistance& dist = this->_geometer->answer;
 
-  printf("---->%g P1=(%g, %g, %g) P2=(%g,%g,%g) N=(%g, %g, %g)\n", dist.value,
-          dist.x1, dist.y1, dist.z1,
-          dist.x2, dist.y2, dist.z2,
-          dist.nx, dist.ny, dist.nz);
+  DEBUG_PRINTF("---->%g P1=(%g, %g, %g) P2=(%g,%g,%g) N=(%g, %g, %g)\n", dist.value,
+               dist.x1, dist.y1, dist.z1,
+               dist.x2, dist.y2, dist.z2,
+               dist.nx, dist.ny, dist.nz);
 
   double& X1 = dist.x1;
   double& Y1 = dist.y1;

--- a/mechanics/src/occ/OccTimeStepping.cpp
+++ b/mechanics/src/occ/OccTimeStepping.cpp
@@ -26,13 +26,14 @@ class OccBody;
 
 using namespace Experimental;
 
-struct UpdateContactShapes : public SiconosVisitor
+struct UpdateShapes : public SiconosVisitor
 {
   using SiconosVisitor::visit;
 
   template<typename T>
   void operator() (const T& ds)
   {
+    const_cast<T&>(ds).updateShapes();
     const_cast<T&>(ds).updateContactShapes();
   }
 };
@@ -44,7 +45,7 @@ void OccTimeStepping::updateWorldFromDS()
   DynamicalSystemsGraph::VIterator dsi, dsiend;
   std11::tie(dsi, dsiend) = dsg.vertices();
 
-  Visitor< Classes < OccBody >, UpdateContactShapes >::Make up;
+  Visitor< Classes < OccBody >, UpdateShapes >::Make up;
 
   for (; dsi != dsiend; ++dsi)
   {

--- a/mechanics/src/occ/OccUtils.cpp
+++ b/mechanics/src/occ/OccUtils.cpp
@@ -9,6 +9,7 @@
 
 #include <cadmbtb.hpp>
 
+
 void occ_move(TopoDS_Shape& shape, const SiconosVector& q)
 {
   const gp_Vec translat = gp_Vec(q(0), q(1), q(2));

--- a/mechanics/swig/mechanics/collision/tools.py
+++ b/mechanics/swig/mechanics/collision/tools.py
@@ -1,6 +1,20 @@
 from math import cos, sin
 from numpy.linalg import norm
 
+class Material(object):
+    """Some material properties that may be associated to shapes.
+
+    Parameter
+    ---------
+
+    density: float
+        The material density.
+    """
+
+    def __init__(self,
+                 density):
+        self.density = density
+
 
 class MovedShape(object):
     """A shape with a reference to some shape data and that is moved by a
@@ -111,7 +125,7 @@ class Volume(Shape):
     def __init__(self,
                  shape_data,
                  instance_name=None,
-                 parameters=None,
+                 parameters=Material(density=1),
                  relative_translation=[0, 0, 0],
                  relative_orientation=[1, 0, 0, 0]):
         self.instance_name = instance_name
@@ -174,16 +188,3 @@ class Contactor(Shape):
                                         relative_orientation)
 
 
-class Material(object):
-    """Some material properties that may be associated to shapes.
-
-    Parameter
-    ---------
-
-    density: float
-        The material density.
-    """
-
-    def __init__(self,
-                 density):
-        self.density = density

--- a/mechanics/swig/mechanics/collision/tools.py
+++ b/mechanics/swig/mechanics/collision/tools.py
@@ -1,14 +1,14 @@
 from math import cos, sin
 from numpy.linalg import norm
 
+
 class Material(object):
     """Some material properties that may be associated to shapes.
 
     Parameter
     ---------
 
-    density: float
-        The material density.
+    :density: float, the material density.
     """
 
     def __init__(self,
@@ -28,19 +28,21 @@ class MovedShape(object):
     Parameters
     ----------
 
-    shape_data
-      some instance of an implementation of the shape.
+    :shape_name: a reference name
 
-    relative_translation: array_like of length 3
+    :shape_data: a pointer to actual shape representation
+
+    :relative_translation: array_like of length 3
       translation in the bodyframe coordinates.
 
-    relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
+    :relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
       The orientation of the shape in the bodyframe coordinates.
       It may be expressed with a quaternion [w, x, y, z] or a couple
       ([x, y, z], angle)
     """
     def __init__(self,
-                 shape_data,
+                 shape_name,
+                 shape_data=None,
                  relative_translation=[0, 0, 0],
                  relative_orientation=[1, 0, 0, 0]):
 
@@ -58,6 +60,7 @@ class MovedShape(object):
             assert len(relative_orientation) == 4
             ori = relative_orientation
 
+        self.shape_name = shape_name
         self.data = shape_data
         self.translation = relative_translation
         self.orientation = ori
@@ -70,29 +73,32 @@ class Shape(MovedShape):
     Parameters
     ----------
 
-    shape_data
-        Some instance of an implementation of the shape.
+    :shape_name: a reference name
 
-    instance_name: string, optional
+    :shape_data: a pointer to actual shape representation
+
+    :instance_name: string, optional
         The name of the instance for further reference.
 
-    relative_translation: array_like of length 3
+    :relative_translation: array_like of length 3
         Translation in the bodyframe coordinates.
 
-    relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
+    :relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
         The orientation of the shape in the bodyframe coordinates.
         It may be expressed with a quaternion [w, x, y, z] or a couple
         ([x, y, z], angle)
     """
 
     def __init__(self,
-                 shape_data,
+                 shape_name,
+                 shape_data=None,
                  instance_name=None,
                  relative_translation=[0, 0, 0],
                  relative_orientation=[1, 0, 0, 0]):
 
         self.instance_name = instance_name
-        super(Shape, self).__init__(shape_data,
+        super(Shape, self).__init__(shape_name,
+                                    shape_data,
                                     relative_translation,
                                     relative_orientation)
 
@@ -103,34 +109,37 @@ class Volume(Shape):
     Parameters
     ----------
 
-    shape_data
-        some instance of an implementation of the shape.
+    :shape_name: a reference name
 
-    instance_name: string, optional
+    :shape_data: a pointer to actual shape representation
+
+    :instance_name: string, optional
         The name of the instance for further reference.
 
-    parameters
+    :parameters:
         The parameters associated to the volume.
         This may be information about the material and its density.
 
-    relative_translation: array_like of length 3
+    :relative_translation: array_like of length 3
         translation in the bodyframe coordinates.
 
-    relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
+    :relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
         The orientation of the shape in the bodyframe coordinates.
         It may be expressed with a quaternion [w, x, y, z] or a couple
         ([x, y, z], angle)
     """
 
     def __init__(self,
-                 shape_data,
+                 shape_name,
+                 shape_data=None,
                  instance_name=None,
                  parameters=Material(density=1),
                  relative_translation=[0, 0, 0],
                  relative_orientation=[1, 0, 0, 0]):
         self.instance_name = instance_name
         self.parameters = parameters
-        super(Shape, self).__init__(shape_data,
+        super(Shape, self).__init__(shape_name,
+                                    shape_data,
                                     relative_translation,
                                     relative_orientation)
 
@@ -145,22 +154,23 @@ class Contactor(Shape):
     Parameters
     ----------
 
-    shape_data
-        Some instance of an implementation of the shape.
+    :shape_name: a reference name
 
-    instance_name: string, optional
+    :shape_data: a pointer to actual shape representation
+
+    :instance_name: string, optional
         The name of the instance for further reference.
 
-    collision_group: int
+    :collision_group: int
         The collision group, an integer >= 0.
 
-    parameters: optional
+    :parameters: optional
         Parameters associated to the contactor.
 
-    relative_translation: array_like of length 3
+    :relative_translation: array_like of length 3
         Translation of in the bodyframe coordinates.
 
-    relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
+    :relative_orientation: array_like of length 4 (quaternion) or (axis, angle)
         The orientation of the shape in the bodyframe coordinates.
         It may be expressed with a quaternion [w, x, y, z] or a couple
         ([x, y, z], angle)
@@ -168,7 +178,8 @@ class Contactor(Shape):
     """
 
     def __init__(self,
-                 shape_data,
+                 shape_name,
+                 shape_data=None,
                  instance_name=None,
                  collision_group=0,
                  parameters=None,
@@ -182,7 +193,8 @@ class Contactor(Shape):
         self.contact_type = contact_type
         self.contact_index = contact_index
 
-        super(Contactor, self).__init__(shape_data,
+        super(Contactor, self).__init__(shape_name,
+                                        shape_data,
                                         instance_name,
                                         relative_translation,
                                         relative_orientation)

--- a/mechanics/swig/mechanics/collision/tools.py
+++ b/mechanics/swig/mechanics/collision/tools.py
@@ -12,7 +12,7 @@ class Material(object):
     """
 
     def __init__(self,
-                 density):
+                 density=None):
         self.density = density
 
 
@@ -116,6 +116,9 @@ class Volume(Shape):
     :instance_name: string, optional
         The name of the instance for further reference.
 
+    :mass:
+        The volume mass
+
     :parameters:
         The parameters associated to the volume.
         This may be information about the material and its density.
@@ -133,10 +136,12 @@ class Volume(Shape):
                  shape_name,
                  shape_data=None,
                  instance_name=None,
+                 mass=None,
                  parameters=Material(density=1),
                  relative_translation=[0, 0, 0],
                  relative_orientation=[1, 0, 0, 0]):
         self.instance_name = instance_name
+        self.mass = mass
         self.parameters = parameters
         super(Shape, self).__init__(shape_name,
                                     shape_data,


### PR DESCRIPTION
It is an update for occ bindings.

Although this is not finished. It is usable now and I think we should sync before there are too many differences in mechanics_io and vview.

This provides:

 - occ_slidercrank.py with plugins and boundary conditions.
 - an inertia matrix computation from open cascade (compute_inertia_and_center_of_mass). A Volume class may be used to define volumes with displacements associated with material densities.
 - add all interactions between all contactors of two shapes, if contactors not precised.

some important renaming in mechanics_io & vview to avoid confusions : contactor.name becomes contactor.shape_name (with occ it becomes important to define multiples contactors from the same shape). Note that a compatibility function is provided : upgrade_io_format(filename) to modify old hdf5 files.