### PR TITLE
Zoh fix

### DIFF
--- a/control/src/Controller/Actuator.cpp
+++ b/control/src/Controller/Actuator.cpp
@@ -26,6 +26,11 @@
 #include <iostream>
 #include "NonSmoothDynamicalSystem.hpp"
 
+// #define DEBUG_NOCOLOR
+// #define DEBUG_STDOUT
+// #define DEBUG_MESSAGES
+#include "debug.h"
+
 Actuator::Actuator(): _type(0), _id("none")
 {
 }
@@ -45,6 +50,7 @@ void Actuator::addSensorPtr(SP::ControlSensor newSensor)
 
 void Actuator::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation& s)
 {
+  DEBUG_BEGIN("Actuator::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation& s)\n")
   if (!_sensor)
   {
     RuntimeException::selfThrow("Actuator::initialize - No Sensor given to the Actuator");
@@ -75,6 +81,7 @@ void Actuator::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation
   }
 
   DSG0.u[dsgVD] = _u;
+  DEBUG_END("Actuator::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation& s)\n")
 }
 
 void Actuator::setSizeu(unsigned size)

--- a/control/src/Controller/CommonSMC.cpp
+++ b/control/src/Controller/CommonSMC.cpp
@@ -57,24 +57,21 @@ void CommonSMC::initialize(const NonSmoothDynamicalSystem & nsds, const Simulati
   if (dsType == Type::FirstOrderNonLinearDS)
   {
     _DS_SMC.reset(new FirstOrderNonLinearDS(*(std11::static_pointer_cast<FirstOrderNonLinearDS>(DS))));
-  // We have to reset the _pluginb
-  SP::SiconosVector dummyb(new SiconosVector(_DS_SMC->n(), 0));
-  std11::static_pointer_cast<FirstOrderNonLinearDS>(_DS_SMC)->setbPtr(dummyb);
   }
   else if (dsType == Type::FirstOrderLinearDS)
   {
     _DS_SMC.reset(new FirstOrderLinearDS(*(std11::static_pointer_cast<FirstOrderLinearDS>(DS))));
     std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC)->setComputebFunction(NULL);
-  // We have to reset the _pluginb
-  SP::SiconosVector dummyb(new SiconosVector(_DS_SMC->n(), 0));
-  std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC)->setbPtr(dummyb);
+    // We have to reset the _pluginb
+    SP::SiconosVector dummyb(new SiconosVector(_DS_SMC->n(), 0));
+    std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC)->setbPtr(dummyb);
   }
   else if (dsType == Type::FirstOrderLinearTIDS)
   {
     _DS_SMC.reset(new FirstOrderLinearTIDS(*(std11::static_pointer_cast<FirstOrderLinearTIDS>(DS))));
-  // We have to reset the _pluginb
-  SP::SiconosVector dummyb(new SiconosVector(_DS_SMC->n(), 0));
-  std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC)->setbPtr(dummyb);
+    // We have to reset the _pluginb
+    SP::SiconosVector dummyb(new SiconosVector(_DS_SMC->n(), 0));
+    std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC)->setbPtr(dummyb);
   }
   else
   {
@@ -83,7 +80,7 @@ void CommonSMC::initialize(const NonSmoothDynamicalSystem & nsds, const Simulati
   _DS_SMC->setNumber(999999);
   _DS_SMC->initMemory(1);
   _DS_SMC->swapInMemory();
-
+  //DEBUG_EXPR(_DS_SMC->display(););
 
   // Get the dimension of the output
   // XXX What if there is more than one sensor ...

--- a/control/src/Controller/LinearSMC.cpp
+++ b/control/src/Controller/LinearSMC.cpp
@@ -61,6 +61,7 @@ void LinearSMC::actuate()
   if (!_noUeq)
   {
     computeUeq();
+    // We assert in computeUeq() that the DS is linear.
     FirstOrderLinearDS& LinearDS_SMC = *std11::static_pointer_cast<FirstOrderLinearDS>(_DS_SMC);
     prod(*_B, *_ueq, *(LinearDS_SMC.b()));
   }

--- a/control/src/Controller/LinearSMCOT2.cpp
+++ b/control/src/Controller/LinearSMCOT2.cpp
@@ -27,6 +27,11 @@
 #include "ControlSensor.hpp"
 #include "TimeDiscretisation.hpp"
 #include "NonSmoothDynamicalSystem.hpp"
+//#define DEBUG_WHERE_MESSAGES
+// #define DEBUG_NOCOLOR
+// #define DEBUG_STDOUT
+// #define DEBUG_MESSAGES
+#include "debug.h"
 
 LinearSMCOT2::LinearSMCOT2(SP::ControlSensor sensor): CommonSMC(LINEAR_SMC_OT2, sensor), _coeff(0.0)
 {
@@ -38,6 +43,7 @@ LinearSMCOT2::~LinearSMCOT2()
 
 void LinearSMCOT2::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation & s)
 {
+  DEBUG_BEGIN(" LinearSMCOT2::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation & s)\n");
   if (!_Csurface)
   {
     RuntimeException::selfThrow("CommonSMC::initialize - you have to set either _Csurface or h(.) before initializing the Actuator");
@@ -83,7 +89,8 @@ void LinearSMCOT2::initialize(const NonSmoothDynamicalSystem& nsds, const Simula
   {
     RuntimeException::selfThrow("LinearSMCOT2 is not yet implemented for system of type" + dsType);
   }
-
+  _DSPred->setNumber(999999);
+  _DSPhi->setNumber(999999);
   // We have to reset _pluginb
   // _DSPhi->setComputebFunction(NULL);
   // _DSPred->setComputebFunction(NULL);
@@ -127,11 +134,12 @@ void LinearSMCOT2::initialize(const NonSmoothDynamicalSystem& nsds, const Simula
   _simulPred->associate(_PredOSI, _DSPred);
 
   _X = _sensor->yTk();
-
+  DEBUG_END(" LinearSMCOT2::initialize(const NonSmoothDynamicalSystem& nsds, const Simulation & s)\n");
 }
 
 void LinearSMCOT2::actuate()
 {
+  DEBUG_BEGIN("LinearSMCOT2::actuate()\n");
   double hCurrent = _tdPhi->currentTimeStep(_indx);
   // Get current value of the state
   // Update it
@@ -164,6 +172,9 @@ void LinearSMCOT2::actuate()
   // Compute \hat{x}_k
   _simulPred->advanceToEvent();
   _simulPred->processEvents();
+  DEBUG_EXPR(_Xhat->display(););
+  DEBUG_EXPR(_u->display(););
+  DEBUG_END("LinearSMCOT2::actuate()\n");
 }
 
 void LinearSMCOT2::setTimeDiscretisation(const TimeDiscretisation& td)

--- a/control/src/utils/ControlZOHAdditionalTerms.cpp
+++ b/control/src/utils/ControlZOHAdditionalTerms.cpp
@@ -35,7 +35,7 @@ void ControlZOHAdditionalTerms::init(DynamicalSystemsGraph& DSG0,
                                      const NonSmoothDynamicalSystem & nsds,
                                      const TimeDiscretisation & td)
 {
-  DEBUG_BEGIN("void ControlZOHAdditionalTerms::init(...)\n")
+  DEBUG_BEGIN("void ControlZOHAdditionalTerms::init(...)\n");
   DynamicalSystemsGraph::VIterator dsvi, dsvdend;
   for (std11::tie(dsvi, dsvdend) = DSG0.vertices(); dsvi != dsvdend; ++dsvi)
   {
@@ -43,21 +43,35 @@ void ControlZOHAdditionalTerms::init(DynamicalSystemsGraph& DSG0,
     if (DSG0.B.hasKey(*dsvi))
     {
       DSG0.Bd[*dsvi].reset(new MatrixIntegrator(ds, nsds, td, DSG0.B[*dsvi]));
+      DSG0.Bd[*dsvi]->setName("MatrixIntegrator for additional term part (Bd) (unplugged version)");
       if (DSG0.Bd.at(*dsvi)->isConst())
+      {
+        DEBUG_PRINT("The system is assumed to be constant and is integrated for computing Bd\n");
         DSG0.Bd.at(*dsvi)->integrate();
+      }
     }
     if (DSG0.L.hasKey(*dsvi))
     {
       DSG0.Ld[*dsvi].reset(new MatrixIntegrator(ds, nsds, td, DSG0.L[*dsvi]));
+      DSG0.Ld[*dsvi]->setName("MatrixIntegrator for additional term part (Ld) (unplugged version)");
       if (DSG0.Ld.at(*dsvi)->isConst())
+      {
+        DEBUG_PRINT("The system  is assumed to be constant and  is integrated for computing Ld\n");
         DSG0.Ld.at(*dsvi)->integrate();
+      }
     }
     if (DSG0.pluginB.hasKey(*dsvi))
+    {
       DSG0.Bd[*dsvi].reset(new MatrixIntegrator(ds, nsds, td, DSG0.pluginB[*dsvi], DSG0.u[*dsvi]->size()));
+      DSG0.Bd[*dsvi]->setName("MatrixIntegrator for additional term part (Bd) (plugged version)");
+    }
     if (DSG0.pluginL.hasKey(*dsvi))
+    {
       DSG0.Ld[*dsvi].reset(new MatrixIntegrator(ds, nsds, td, DSG0.pluginL[*dsvi], DSG0.e[*dsvi]->size()));
+      DSG0.Ld[*dsvi]->setName("MatrixIntegrator for additional term part (Ld) (unplugged version)");
+    }
   }
-  DEBUG_END("void ControlZOHAdditionalTerms::init(...)\n")
+  DEBUG_END("void ControlZOHAdditionalTerms::init(...)\n");
 }
 
 void ControlZOHAdditionalTerms::addSmoothTerms(DynamicalSystemsGraph& DSG0,
@@ -68,20 +82,21 @@ void ControlZOHAdditionalTerms::addSmoothTerms(DynamicalSystemsGraph& DSG0,
   // check whether we have a system with a control input
   if (DSG0.u.hasKey(dsgVD))
   {
-    DEBUG_PRINT("a system has a control input\n");
+    DEBUG_PRINT("The dynamical system has a control input\n");
     assert(DSG0.Bd.hasKey(dsgVD));
     if (!DSG0.Bd.at(dsgVD)->isConst())
     {
       DSG0.Bd.at(dsgVD)->integrate();
     }
     DEBUG_EXPR(DSG0.Bd.at(dsgVD)->mat().display());
-    DEBUG_EXPR(xfree.display());
     DEBUG_EXPR((*DSG0.u.at(dsgVD)).display());
     prod(DSG0.Bd.at(dsgVD)->mat(), *DSG0.u.at(dsgVD), xfree, false); // xfree += Bd*u
+    DEBUG_EXPR(xfree.display());
   }
   // check whether the DynamicalSystem is an Observer
   if (DSG0.e.hasKey(dsgVD))
   {
+    DEBUG_PRINT("The dynamical system is an Observer\n");
     assert(DSG0.Ld.hasKey(dsgVD));
     if (!DSG0.Ld.at(dsgVD)->isConst())
     {

--- a/control/swig/tests/test_smc.py
+++ b/control/swig/tests/test_smc.py
@@ -9,7 +9,7 @@ def test_smc1():
     from siconos.control.simulation import ControlManager
     from siconos.control.sensor import LinearSensor
     from siconos.control.controller import LinearSMCOT2
-    from numpy import eye, empty, zeros
+    from numpy import eye, empty, zeros, savetxt
     import numpy as np
     from math import ceil, sin
 
@@ -98,7 +98,8 @@ def test_smc1():
     #    print processSimulation.nextTime()
     # Resize matrix
     dataPlot.resize(k, outputSize)
-
+    np.savetxt("smc_1.dat", dataPlot)
+    #savetxt("test_smc1.txt", dataPlot)
 
 # Same test, but with the simplified interface
 def test_smc2():
@@ -116,6 +117,7 @@ def test_smc2():
         def computeb(self, time):
             t = sin(50*time)
             u = [t, -t]
+            print('u', u)
             self.setbPtr(u)
 
     # variable declaration
@@ -170,7 +172,8 @@ def test_smc2():
     assert norm(dataPlot - ref) < 5e-12
 
 if __name__ == '__main__':
-    print('test_smc1')
-    test_smc1()
+    #print('test_smc1')
+    #test_smc1()
+    print('test_smc2')
     test_smc2()
     

--- a/examples/Control/ZeroOrderHold/ZeroOrderHold.cpp
+++ b/examples/Control/ZeroOrderHold/ZeroOrderHold.cpp
@@ -1,0 +1,154 @@
+/* Siconos is a program dedicated to modeling, simulation and control
+ * of non smooth dynamical systems.
+ *
+ * Copyright 2016 INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/* !\file ZeroOrderHold.cpp
+  */
+
+#include "SiconosKernel.hpp"
+#include "SiconosControl.hpp"
+using namespace std;
+class MyDS : public FirstOrderLinearDS
+{
+public:
+  MyDS(SP::SiconosVector x0, SP::SiconosMatrix A) : FirstOrderLinearDS(x0, A)
+  {
+    _b.reset(new SiconosVector(x0->size()));
+  };
+  void computeb(double time)
+  {
+    printf("computeB\n");
+    double t = sin(50 * time);
+    _b->setValue(0,t);
+    _b->setValue(1,-t);
+    printf("b[0] = %g, b[1] = %g\n", _b->getValue(0), _b->getValue(1));
+  };
+};
+// main program
+int main(int argc, char* argv[])
+{
+  // User-defined parameters
+  unsigned int ndof = 2;          // Number of degrees of freedom of your system
+  double t0 = 0.0;                // Starting time
+  double T = 1;                   // Total simulation time
+  double h = 1.0e-3;              // Time step for simulation
+  double Xinit = 1.0;
+
+  // ================= Creation of the model =======================
+  // Steps:
+  // - create a Dynamical System
+  // - add a Simulation to the model
+
+  // -------------------------
+  // --- Dynamical systems ---
+  // -------------------------
+
+  // First System:
+  // dx/dt = Ax + u(t) + r
+  // x(0) = x0
+  // Note: r = Blambda, B defines in relation below.
+
+  // Matrix declaration
+  SP::SiconosMatrix A(new SimpleMatrix(ndof, ndof, 0));
+  SP::SiconosVector x0(new SiconosVector(ndof));
+  (*x0)(0) = Xinit;
+  (*x0)(1) = -Xinit;
+  SP::SimpleMatrix sensorC(new SimpleMatrix(2, 2));
+  sensorC->eye();
+  SP::SimpleMatrix sensorD(new SimpleMatrix(2, 2, 0));
+  SP::SimpleMatrix Csurface(new SimpleMatrix(1, 2, 0));
+  (*Csurface)(0, 1) = 1;
+  SP::SimpleMatrix Brel(new SimpleMatrix(2, 1, 0));
+  (*Brel)(1, 0) = 2;
+
+  // Dynamical Systems
+  SP::FirstOrderLinearDS processDS(new MyDS(x0, A));
+
+
+  SP::NonSmoothDynamicalSystem nsds(new NonSmoothDynamicalSystem(t0, T));
+  nsds->insertDynamicalSystem(processDS);
+
+  // TimeDiscretisation
+  SP::TimeDiscretisation td(new TimeDiscretisation(t0, h));
+  // == Creation of the Simulation ==
+  SP::TimeStepping s(new TimeStepping(nsds, td));
+
+  // -- OneStepIntegrators --
+  SP::ZeroOrderHoldOSI myIntegrator(new ZeroOrderHoldOSI());
+  s->insertIntegrator(myIntegrator);
+
+  // =========================== End of model definition ===========================
+
+  // ================================= Computation =================================
+
+  // --- Simulation initialization ---
+
+  // --- Get the values to be plotted ---
+  unsigned int outputSize = 3; // number of required data
+  unsigned int N = ceil((T - t0) / h); // Number of time steps
+
+  SimpleMatrix dataPlot(N, outputSize);
+
+  SP::SiconosVector xProc = processDS->x();
+
+
+  // -> saved in a matrix dataPlot
+  dataPlot(0, 0) = nsds->t0(); // Initial time of the model
+  dataPlot(0, 1) = (*xProc)(0);
+  dataPlot(0, 2) = (*xProc)(1);
+
+  // ==== Simulation loop =====
+  cout << "====> Start computation ... " << endl << endl;
+
+  // *z = *(myProcessInteraction->y(0)->getVectorPtr(0));
+  unsigned int k = 0; // Current step
+
+  // Simulation loop
+  boost::timer time;
+  time.restart();
+  while (k < N - 1)
+  {
+    k++;
+    //  *z = *(myProcessInteraction->y(0)->getVectorPtr(0));
+    s->computeOneStep();
+    dataPlot(k, 0) = s->nextTime();
+    dataPlot(k, 1) = (*xProc)(0);
+    dataPlot(k, 2) = (*xProc)(1);
+    s->nextStep();
+  }
+  cout << endl << "End of computation - Number of iterations done: " << k - 1 << endl;
+  cout << "Computation Time " << time.elapsed()  << endl;
+
+
+  // --- Output files ---
+  cout << "====> Output file writing ..." << endl;
+
+  ioMatrix::write("ZeroOrderHold.dat", "ascii", dataPlot, "noDim");
+
+  // // Comparison with a reference file
+  // SimpleMatrix dataPlotRef(dataPlot);
+  // dataPlotRef.zero();
+  // ioMatrix::read("SMCExampleImplicit.ref", "ascii", dataPlotRef);
+  // std::cout << (dataPlot - dataPlotRef).normInf() << std::endl;
+
+  // if ((dataPlot - dataPlotRef).normInf() > 1e-12)
+  // {
+  //   std::cout << "Warning. The results is rather different from the reference file." << std::endl;
+  //   return 1;
+  // }
+
+}

--- a/examples/Control/ZeroOrderHold/ZeroOrderHold_constantDS.cpp
+++ b/examples/Control/ZeroOrderHold/ZeroOrderHold_constantDS.cpp
@@ -1,0 +1,155 @@
+/* Siconos is a program dedicated to modeling, simulation and control
+ * of non smooth dynamical systems.
+ *
+ * Copyright 2016 INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/* !\file ZeroOrderHold.cpp
+  */
+
+#include "SiconosKernel.hpp"
+#include "SiconosControl.hpp"
+using namespace std;
+class MyDS : public FirstOrderLinearDS
+{
+public:
+  MyDS(SP::SiconosVector x0, SP::SiconosMatrix A) : FirstOrderLinearDS(x0, A)
+  {
+    _b.reset(new SiconosVector(x0->size()));
+    _hasConstantB= true;
+    _hasConstantA= true;  
+  };
+  void computeb(double time)
+  {
+    printf("computeB\n");
+    _b->setValue(0,0.2);
+    _b->setValue(1,-0.2);
+    printf("b[0] = %g, b[1] = %g\n", _b->getValue(0), _b->getValue(1));
+  };
+};
+// main program
+int main(int argc, char* argv[])
+{
+  // User-defined parameters
+  unsigned int ndof = 2;          // Number of degrees of freedom of your system
+  double t0 = 0.0;                // Starting time
+  double T = 1;                   // Total simulation time
+  double h = 1.0e-1;              // Time step for simulation
+  double Xinit = 1.0;
+
+  // ================= Creation of the model =======================
+  // Steps:
+  // - create a Dynamical System
+  // - add a Simulation to the model
+
+  // -------------------------
+  // --- Dynamical systems ---
+  // -------------------------
+
+  // First System:
+  // dx/dt = Ax + u(t) + r
+  // x(0) = x0
+  // Note: r = Blambda, B defines in relation below.
+
+  // Matrix declaration
+  SP::SiconosMatrix A(new SimpleMatrix(ndof, ndof, 0));
+  SP::SiconosVector x0(new SiconosVector(ndof));
+  (*x0)(0) = Xinit;
+  (*x0)(1) = -Xinit;
+  SP::SimpleMatrix sensorC(new SimpleMatrix(2, 2));
+  sensorC->eye();
+  SP::SimpleMatrix sensorD(new SimpleMatrix(2, 2, 0));
+  SP::SimpleMatrix Csurface(new SimpleMatrix(1, 2, 0));
+  (*Csurface)(0, 1) = 1;
+  SP::SimpleMatrix Brel(new SimpleMatrix(2, 1, 0));
+  (*Brel)(1, 0) = 2;
+
+  // Dynamical Systems
+  SP::FirstOrderLinearDS processDS(new MyDS(x0, A));
+
+
+  SP::NonSmoothDynamicalSystem nsds(new NonSmoothDynamicalSystem(t0, T));
+  nsds->insertDynamicalSystem(processDS);
+
+  // TimeDiscretisation
+  SP::TimeDiscretisation td(new TimeDiscretisation(t0, h));
+  // == Creation of the Simulation ==
+  SP::TimeStepping s(new TimeStepping(nsds, td));
+
+  // -- OneStepIntegrators --
+  SP::ZeroOrderHoldOSI myIntegrator(new ZeroOrderHoldOSI());
+  s->insertIntegrator(myIntegrator);
+
+  // =========================== End of model definition ===========================
+
+  // ================================= Computation =================================
+
+  // --- Simulation initialization ---
+
+  // --- Get the values to be plotted ---
+  unsigned int outputSize = 3; // number of required data
+  unsigned int N = ceil((T - t0) / h); // Number of time steps
+
+  SimpleMatrix dataPlot(N, outputSize);
+
+  SP::SiconosVector xProc = processDS->x();
+
+
+  // -> saved in a matrix dataPlot
+  dataPlot(0, 0) = nsds->t0(); // Initial time of the model
+  dataPlot(0, 1) = (*xProc)(0);
+  dataPlot(0, 2) = (*xProc)(1);
+
+  // ==== Simulation loop =====
+  cout << "====> Start computation ... " << endl << endl;
+
+  // *z = *(myProcessInteraction->y(0)->getVectorPtr(0));
+  unsigned int k = 0; // Current step
+
+  // Simulation loop
+  boost::timer time;
+  time.restart();
+  while (k < N - 1)
+  {
+    k++;
+    //  *z = *(myProcessInteraction->y(0)->getVectorPtr(0));
+    s->computeOneStep();
+    dataPlot(k, 0) = s->nextTime();
+    dataPlot(k, 1) = (*xProc)(0);
+    dataPlot(k, 2) = (*xProc)(1);
+    s->nextStep();
+  }
+  cout << endl << "End of computation - Number of iterations done: " << k - 1 << endl;
+  cout << "Computation Time " << time.elapsed()  << endl;
+
+
+  // --- Output files ---
+  cout << "====> Output file writing ..." << endl;
+
+  ioMatrix::write("ZeroOrderHold_constantDS.dat", "ascii", dataPlot, "noDim");
+
+  // // Comparison with a reference file
+  // SimpleMatrix dataPlotRef(dataPlot);
+  // dataPlotRef.zero();
+  // ioMatrix::read("SMCExampleImplicit.ref", "ascii", dataPlotRef);
+  // std::cout << (dataPlot - dataPlotRef).normInf() << std::endl;
+
+  // if ((dataPlot - dataPlotRef).normInf() > 1e-12)
+  // {
+  //   std::cout << "Warning. The results is rather different from the reference file." << std::endl;
+  //   return 1;
+  // }
+
+}

--- a/examples/Control/ZeroOrderHold/ZeroOrderHold_folds_inheritance.cpp
+++ b/examples/Control/ZeroOrderHold/ZeroOrderHold_folds_inheritance.cpp
@@ -25,10 +25,29 @@ using namespace std;
 class MyDS : public FirstOrderLinearDS
 {
 public:
-  MyDS(SP::SiconosVector x0, SP::SiconosMatrix A) : FirstOrderLinearDS(x0, A)
+  MyDS(SP::SiconosVector x0) : FirstOrderLinearDS(x0)
   {
     _b.reset(new SiconosVector(x0->size()));
+    _A.reset(new SimpleMatrix(x0->size(), x0->size(), 0));
   };
+  MyDS(const MyDS & myds) : FirstOrderLinearDS(myds)
+  {
+    // copy constructor
+    std::cout << "copy constructor" << std::endl;
+  };
+
+  
+
+  
+  void computeA(double time)
+  {
+    printf("computeA\n");
+    double t = sin(50 * time);
+    _A->eye();
+    *_A  = t * *_A;
+    _A->display();
+  };
+  
   void computeb(double time)
   {
     printf("computeB\n");
@@ -76,7 +95,7 @@ int main(int argc, char* argv[])
   (*Brel)(1, 0) = 2;
 
   // Dynamical Systems
-  SP::FirstOrderLinearDS processDS(new MyDS(x0, A));
+  SP::FirstOrderLinearDS processDS(new MyDS(x0));
 
 
   SP::NonSmoothDynamicalSystem nsds(new NonSmoothDynamicalSystem(t0, T));

--- a/kernel/src/simulationTools/EulerMoreauOSI.cpp
+++ b/kernel/src/simulationTools/EulerMoreauOSI.cpp
@@ -160,7 +160,8 @@ void EulerMoreauOSI::initializeWorkVectorsForInteraction(Interaction &inter,
 
   RELATION::TYPES relationType = relation.getType();
   RELATION::SUBTYPES relationSubType = relation.getSubType();
-  workV[OneStepIntegrator::osnsp_rhs].reset(new SiconosVector(inter.getSizeOfY()));
+  if(!workV[OneStepIntegrator::osnsp_rhs])
+    workV[OneStepIntegrator::osnsp_rhs].reset(new SiconosVector(inter.getSizeOfY()));
 
   // Check if interations levels (i.e. y and lambda sizes) are compliant with the current osi.
   _check_and_update_interaction_levels(inter);

--- a/kernel/src/simulationTools/MatrixIntegrator.cpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.cpp
@@ -27,21 +27,21 @@
 #include "EventsManager.hpp"
 
 //#define DEBUG_WHERE_MESSAGES
-
-// #define DEBUG_NOCOLOR
-// #define DEBUG_STDOUT
-// #define DEBUG_MESSAGES
-
+#define DEBUG_NOCOLOR
+#define DEBUG_STDOUT
+#define DEBUG_MESSAGES
 #include <debug.h>
 
-MatrixIntegrator::MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const  TimeDiscretisation & td, SP::SiconosMatrix E): _E(E)
+MatrixIntegrator::MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds,
+                                   const  TimeDiscretisation & td, SP::SiconosMatrix E): _E(E)
 {
   commonInit(ds, nsds, td);
   _mat.reset(new SimpleMatrix(*E));
   _mat->zero();
 }
 
-MatrixIntegrator::MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation & td, SP::PluggedObject plugin, const unsigned int p):
+MatrixIntegrator::MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds,
+                                   const TimeDiscretisation & td, SP::PluggedObject plugin, const unsigned int p):
   _plugin(plugin)
 {
   commonInit(ds, nsds, td);
@@ -61,6 +61,7 @@ MatrixIntegrator::MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDyn
 
 void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation & td)
 {
+  DEBUG_BEGIN("MatrixIntegrator::commonInit(...)\n");
   _TD.reset(new TimeDiscretisation(td));
 
   DEBUG_EXPR(ds.display(););
@@ -76,12 +77,27 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const NonSmoothDyna
   {
      const FirstOrderLinearDS& cfolds = static_cast<const FirstOrderLinearDS&>(ds);
      _DS.reset(new FirstOrderLinearDS(cfolds));
-     // std11::static_pointer_cast<FirstOrderLinearDS>(_DS)->zeroPlugin();
-     if (cfolds.getPluginA()->isPlugged())
+     if (_E)
      {
-       std11::static_pointer_cast<FirstOrderLinearDS>(_DS)->setPluginA(cfolds.getPluginA());
+       DEBUG_PRINT("Matrix integration of the constant (possibly time variant) part\n");
+       if (cfolds.getPluginB()->isPlugged())
+       {
+         DEBUG_PRINT("B is plugged\n");
+         std11::static_pointer_cast<FirstOrderLinearDS>(_DS)->setPluginB(cfolds.getPluginB());
+       }
+       _isConst = (_TD->hConst()) && (cfolds.hasConstantB()) ? true : false;
      }
-     _isConst = (_TD->hConst()) && !(cfolds.getPluginA()->isPlugged()) ? true : false;
+     else
+     {
+       DEBUG_PRINT("Matrix integration of the linear (possibly time variant) part\n");
+       if (cfolds.getPluginA()->isPlugged())
+       {
+         DEBUG_PRINT("A is plugged\n");
+         std11::static_pointer_cast<FirstOrderLinearDS>(_DS)->setPluginA(cfolds.getPluginA());
+       }
+       _isConst = (_TD->hConst()) && (cfolds.hasConstantA()) ? true : false;
+     }
+     //_isConst = (_TD->hConst()) && !(cfolds.getPluginA()->isPlugged()) && !(cfolds.getPluginB()->isPlugged()) ? true : false;
   }
 
   _DS->setNumber(9999999);
@@ -99,32 +115,44 @@ void MatrixIntegrator::commonInit(const DynamicalSystem& ds, const NonSmoothDyna
   _sim->setName("Matrix integrator simulation");
   //change tolerance
   _OSI->setTol(1, 10 * MACHINE_PREC, 5 * MACHINE_PREC);
-
+  DEBUG_END("MatrixIntegrator::commonInit(...)\n");
 }
 
 void MatrixIntegrator::integrate()
 {
   DEBUG_BEGIN("MatrixIntegrator::integrate()\n");
+  DEBUG_EXPR(std::cout << name() << std::endl ; );
   SiconosVector& x0 = *_DS->x0();
   SiconosVector& x = *_DS->x();
 
   SP::SiconosVector Ecol = static_cast<FirstOrderLinearDS&>(*_DS).b();
+ 
+  
   if (!Ecol && _E)
   {
+    DEBUG_PRINT("!Ecol && _E. we reset Ecol\n");
     Ecol.reset(new SiconosVector(_DS->n(), 0));
     static_cast<FirstOrderLinearDS&>(*_DS).setbPtr(Ecol);
   }
+  
   unsigned int p = _mat->size(1);
   for (unsigned int i = 0; i < p; i++)
   {
+    
     x0.zero();
     if (_E)
       _E->getCol(i, *Ecol);
     else if (_plugin)
       _spo->setIndex(i);
     else
+    {
       x0(i) = 1;
-
+    }
+    
+    DEBUG_EXPR(if (_E) _E->display(););
+    DEBUG_EXPR(Ecol->display(););
+    DEBUG_EXPR(x0.display(););
+    DEBUG_PRINTF("integration interval = [%g,%g]", _sim->getTk(), _sim->getTkp1());
     //Reset LsodarOSI
     //_OSI->setIsInitialized(false);
     _DS->resetToInitialState();

--- a/kernel/src/simulationTools/MatrixIntegrator.hpp
+++ b/kernel/src/simulationTools/MatrixIntegrator.hpp
@@ -38,16 +38,19 @@ private:
 
 protected:
 
+  /** name or id of the MatrixIntegrator */
+  std::string _name;
+  
   /** The matrix solution to the ODE */
   SP::SiconosMatrix _mat;
 
-  /**The entry Matrix E */
+  /** The entry Matrix E */
   SP::SiconosMatrix _E;
 
-  /**The entry Matrix E, in the plugin form */
+  /** The entry Matrix E, in the plugin form */
   SP::PluggedObject _plugin;
 
-  /**Plugin to compute the value of a column of E */
+  /** Plugin to compute the value of a column of E */
   SP::SubPluggedObject _spo;
 
   /** flag to indicate where the Matrix _mat is constant */
@@ -76,24 +79,43 @@ protected:
 
 public:
 
+  /** get the name of the MatrixIntegrator
+   *  \return std::string : the name of the MatrixIntegrator
+   */
+  inline const std::string name() const
+  {
+    return _name;
+  }
+
+  /** set the name of the MatrixIntegrator
+      \param newName the new name
+   */
+  inline void setName(const std::string& newName)
+  {
+    _name = newName;
+  }
+
+
+  
   /** Constructor to compute \f$\int exp(A\tau)E\amthrm{d}\tau\f$
    * \param ds the DynamicalSystem
-   * \param m the original Model
+   * \param nsds the original  nsds
    * \param E a matrix
    */
   MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation &td, const  SP::SiconosMatrix E);
 
   /** Constructor to compute \f$\int exp(A\tau)E(\tau)\mathrm{d}\tau\f$
    * \param ds the DynamicalSystem
-   * \param m the original Model
+   * \param nsds the original  nsds
    * \param plugin the plugin to compute \f$E(t)\f$
    * \param p the number of column in E
    */
-  MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation &td, SP::PluggedObject plugin, const unsigned int p);
+  MatrixIntegrator(const DynamicalSystem& ds, const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation &td,
+                   SP::PluggedObject plugin, const unsigned int p);
 
   /** Constructor to compute \f$\int exp(A\tau)\mathrm{d}\tau\f$
    * \param ds the DynamicalSystem
-   * \param m the original Model
+   * \param nsds the original  nsds
    */
   MatrixIntegrator(const DynamicalSystem& ds,const NonSmoothDynamicalSystem& nsds, const TimeDiscretisation &td);
 


### PR DESCRIPTION
I open this new PR with the corresponding branch to try to fix the problem (to the definition ...) of ZOH integrator for the FirstOrderLinearDS of the form

<img src="https://latex.codecogs.com/svg.latex?\Large&space;\dot{x}(t)=A(t)x(t)+b(t)+B(t)u" title="\Large \dot{x}(t)=A(t)x(t)+b(t)+B(t)u" />

when b and B are varying with time. The Duhamel formulae is

<img src="https://latex.codecogs.com/svg.latex?\Large&space;x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)b(s)ds+\int_{t_0}^{t}R(t,s)B(s)ds\,u" title="\Large  x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)b(s)ds+\int_{t_0}^{t}R(t,s)B(s)ds\,u" />

where R(t,s) is the resolvent, solution of the matrix ODE system

<img src="https://latex.codecogs.com/svg.latex?\Large&space;\frac{\partial}{\partial{t}}R(t,s)=A(t)R(t,s)" title="\Large  x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)b(s)ds" />

with 

<img src="https://latex.codecogs.com/svg.latex?\Large&space;R(s,s)=I_{n\times{}n}" title="\Large  x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)b(s)ds" />

Let us assume for a while that A is time invariant, that is <img src="https://latex.codecogs.com/svg.latex?\Large&space;A(t)=A\forall{}t" title="\Large " />, then the resolvent is given by 

<img src="https://latex.codecogs.com/svg.latex?\Large&space;R(t,s)=\exp((t-s)A)." title="\Large " />,
and the Duhamel formula is 

<img src="https://latex.codecogs.com/svg.latex?\Large&space;x(t)=\exp((t-t_0)A)x_0+\int_{t_0}^{t}\exp((t-s)A)b(s)ds+\int_{t_0}^{t}\exp((t-s)A)B(s)ds\,u" title="\Large  x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)b(s)ds+\int_{t_0}^{t}\exp((t-s)A)B(s)ds\,u" />

Furthermore, if b and B are time invariant that is b(t) = b,\, B(t) =B \forall t, then we obtain

<img src="https://latex.codecogs.com/svg.latex?\Large&space;x(t)=\exp((t-t_0)A)x_0+\int_{t_0}^{t}\exp((t-s)A)ds\,b+\int_{t_0}^{t}\exp((t-s)A)ds\,Bu" title="\Large  x(t)=R(t,t_0)x_0+\int_{t_0}^{t}R(t,s)ds\,b+\int_{t_0}^{t}\exp((t-s)A)ds\,Bu" />

FirstOrderLinearTIDS
---------------------

For FirstOrderLinearTIDS, there is no ambiguity on the definition of the ZOH integrator, we define for a fixed given time step h = t_{k+1}-t_{k},  the following matrix

<img src="https://latex.codecogs.com/svg.latex?\Large&space;Ad=\exp(hA)" title="\Large  " />

and 

<img src="https://latex.codecogs.com/svg.latex?\Large&space;AdInt=\int_{t_k}^{t_{k+1}}\exp(t_{k+1}-s)A)ds" title="\Large  " />

and the following integration rule defines the ZOH integrator

<img src="https://latex.codecogs.com/svg.latex?\Large&space;x_{k+1}=Ad\,x_{k}+AdInt\,b+AdInt\,Bu" title="\Large  " />

FirstOrderLinearDS
-------------------

For FirstOrderLinearDS, the implementation in siconos is not very clear and depends strongly on the way the example is implemented with inherited class or plugins.

In the MatrixIntegrator contractors, the dynamical system to be integrated is copied using the type of the Dynamical systems and the copy constructor.

* If the methods computeA and computeB are reimplemented  in the derived class, they are not called but the Matrix integrator. So using inherited classes, do not use the methods computeA and computeB. The ZeroOrderHold OSI "works" if we give a constant A matrix (in the constructor or thanks to setA method) and we give a method for computeB use by the ZeroOrderHold. we obtain
<img src="https://latex.codecogs.com/svg.latex?\Large&space;x_{k+1}=Ad\,x_{k}+AdInt\,b+AdInt\,Bu" title="\Large  " />

with
<img src="https://latex.codecogs.com/svg.latex?\Large&space;Ad=R(t_k+h,t_k)" title="\Large  " />

and 

<img src="https://latex.codecogs.com/svg.latex?\Large&space;AdInt=\int_{t_k}^{t_{k+1}}R(t_{k+1},s)ds" title="\Large  " />

* With plugins, the implemented differs since we copy explicitly the plugin.





