### PR TITLE
Build without path and sort

### DIFF
--- a/cmake/siconos_find_common_dep.cmake
+++ b/cmake/siconos_find_common_dep.cmake
@@ -52,6 +52,7 @@ if (WITH_SYSTEM_SUITESPARSE)
   set(USE_SYSTEM_SUITESPARSE ${_sys_CXSparse} CACHE INTERNAL "flag to check to systemwide SuiteSparse install")
 endif()
 
+# --- Other solvers ---
 compile_with(PathFerris SICONOS_COMPONENTS numerics)
 compile_with(PathVI SICONOS_COMPONENTS numerics)
 compile_with(LpSolve SICONOS_COMPONENTS numerics)
@@ -60,6 +61,13 @@ if(LpSolve_FOUND)
   set(HAS_EXTREME_POINT_ALGO TRUE)
   set(WITH_LPSOLVE TRUE)
 endif(LpSolve_FOUND)
+
+# --- Sort ---
+if(EXISTS "${CMAKE_SOURCE_DIR}/externals/sort/sort.h")
+  if(EXISTS "${CMAKE_SOURCE_DIR}/externals/sort/sort_common.h")
+    set(HAVE_SORT TRUE)
+  endif()
+endif()
 
 # --- Mumps ---
 if(WITH_MUMPS)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -8,6 +8,7 @@
 #cmakedefine HAVE_SICONOS_CONTROL
 #cmakedefine HAVE_PATHFERRIS
 #cmakedefine HAVE_PATHVI
+#cmakedefine HAVE_SORT
 #cmakedefine HAVE_MLCPSIMPLEX
 #cmakedefine HAVE_TIME_H
 #cmakedefine HAVE_SYSTIMES_H

--- a/numerics/src/tools/InterfaceToPathFerris/SimpleLCP.h
+++ b/numerics/src/tools/InterfaceToPathFerris/SimpleLCP.h
@@ -51,9 +51,11 @@
 #include "SiconosConfig.h"
 #include <stdint.h>
 
-
+#ifdef HAVE_PATHFERRIS
 #include "PATH_SDK/include/Types.h"
-
+#else
+typedef void MCP_Termination;
+#endif
 
 //const unsigned short int *__ctype_b;
 //const int32_t *__ctype_tolower ;

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -27,6 +27,7 @@
 #include "NumericsSparseMatrix.h"
 #include "numerics_verbose.h"
 #include "NumericsMatrix.h"
+#include "string.h" // memcpy
 
 #include "debug.h"
 

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -45,10 +45,20 @@ typedef struct
   size_t indx;
 } sort_indices_struct;
 
+#ifdef HAVE_SORT
 #define SORT_NAME sorter
 #define SORT_TYPE sort_indices_struct
 #define SORT_CMP(x, y) ((x).i - (y).i)
 #include "sort.h"
+#else
+#include "stdlib.h" // qsort
+static int sort_indices_struct_cmp(const void *a, const void *b)
+{
+  const sort_indices_struct *sa = (const sort_indices_struct *) a;
+  const sort_indices_struct *sb = (const sort_indices_struct *) b;
+  return (sa->i > sb->i) - (sa->i < sb->i);
+}
+#endif
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
@@ -291,7 +301,12 @@ void NSM_fix_csc(CSparseMatrix* A)
         s[i].indx = i;
       }
 
-      sorter_tim_sort(s, len);
+#ifdef HAVE_SORT
+        sorter_tim_sort(s, len);
+#else
+        qsort(s, len, sizeof(sort_indices_struct),
+              sort_indices_struct_cmp);
+#endif
 
       for (size_t i = 0, pp = ps; i < len; ++i, ++pp)
       {


### PR DESCRIPTION
These two patches make the build work if I remove folders externals/PATH_SDK and externals/sort.  These are the two main license-related pain points for #236.  Please review.