### PR TITLE
New vview

### DIFF
--- a/io/swig/io/mechanics_run.py
+++ b/io/swig/io/mechanics_run.py
@@ -909,23 +909,22 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
                 }
 
             else:
-                # a moving object
 
-                if inertia is not None:
-                    if np.shape(inertia) == (3,):
+                if inertia is not None and np.shape(inertia) == (3,):
                         inertia = np.diag(inertia)
-                    elif np.shape(inertia) != (3,3):
-                        print('Wrong shape of inertia')
-                    have_inertia = True
-                else:
-                    inertia=0.0*np.eye(3) # set a temporary null value
-                    have_inertia = False
 
-                body = body_class(translation + orientation,
-                                  velocity,
-                                  mass, inertia)
-                if have_inertia:
+                if inertia is not None and np.shape(inertia) == (3,3):
+                    body = body_class(translation + orientation,
+                                      velocity, mass, inertia)
                     body.setUseContactorInertia(False)
+                else:
+                    if inertia is not None:
+                        print('**** Warning inertia for object named {0} does not have the correct shape: {1} instead of (3, 3) or (3,)'.format(name, np.shape(inertia)))
+                        print('**** Inertia will be computed with the shape of the first contactor')
+                    body = body_class(translation + orientation,
+                                      velocity, mass)
+                    body.setUseContactorInertia(True)
+
 
                 self_collide = self._input[name].get('allow_self_collide',None)
                 if self_collide is not None:

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -347,7 +347,6 @@ class CFprov():
         from vtk.numpy_interface import dataset_adapter as dsa
 
         self._ioreader = ioreader
-        self._data = self._ioreader.cf_data
         
         self.cpa_at_time = dict()
         self.cpa = dict()
@@ -403,22 +402,23 @@ class CFprov():
                         
     def xmethod(self):
         
-        if self._data is not None:
+        if self._ioreader.cf_data is not None:
 
-            mus, imus = numpy.unique(self._data[:, 1], return_inverse=True)
+            data = self._ioreader.cf_data
+            mus, imus = numpy.unique(data[:, 1], return_inverse=True)
 
-            #print('xmethod', self._data[i, 2:5]))
+            #print('xmethod', data[i, 2:5]))
             for i, imu in enumerate(imus):
                 mu = mus[imu]
                 fdata = self._output[mu].GetFieldData()
                         
-                numpy.copyto(fdata['contactPositionsA'], self._data[
+                numpy.copyto(fdata['contactPositionsA'], data[
                     i, 2:5])
-                numpy.copyto(fdata['contactPositionsB'], self._data[
+                numpy.copyto(fdata['contactPositionsB'], data[
                     i, 5:8])
-                numpy.copyto(fdata['contactNormals'], self._data[
+                numpy.copyto(fdata['contactNormals'], data[
                     i, 8:11])
-                numpy.copyto(fdata['contactForces'], self._data[
+                numpy.copyto(fdata['contactForces'], data[
                     i, 11:14])
 
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -803,11 +803,12 @@ class IOReader(VTKPythonAlgorithmBase):
                             imu, 8:11]
                         self.cf_at_time[mu] = data[
                             imu, 11:14]
-                        if len(data[imu,:]) > 26:
+                        if data[imu,:].shape[1] > 26:
                             self.ids_at_time[mu] = data[
                                 imu, 23:26].astype(int)
                         else:
-                            self.ids_at_time[mu] = [[nan, nan, nan]]
+                            self.ids_at_time[mu] = numpy.array(
+                                [[nan, nan, nan]])
 
             else:
                 for mu in self._mu_coefs:
@@ -815,7 +816,7 @@ class IOReader(VTKPythonAlgorithmBase):
                     self.cpb_at_time[mu] = [[nan, nan, nan]]
                     self.cn_at_time[mu] =  [[nan, nan, nan]]
                     self.cf_at_time[mu] =  [[nan, nan, nan]]
-                    self.ids_at_time[mu] = [[nan, nan, nan]]
+                    self.ids_at_time[mu] = numpy.array([[nan, nan, nan]])
 
             for mu in self._mu_coefs:
                 self.cpa[mu] = numpy_support.numpy_to_vtk(
@@ -846,36 +847,35 @@ class IOReader(VTKPythonAlgorithmBase):
                 self._output[mu].GetPointData().AddArray(self.cn[mu])
                 self._output[mu].GetPointData().AddArray(self.cf[mu])
 
-                if self.ids_at_time[mu] is not None:
+                if self.ids_at_time[mu].shape[0] > 0:
                     self.ids[mu] = numpy_support.numpy_to_vtk(
                         self.ids_at_time[mu])
                     self.ids[mu].SetName('ids')
                     self._contact_field[mu].AddArray(self.ids[mu])
                     self._output[mu].GetPointData().AddArray(self.ids[mu])
 
-                    if len(self.ids_at_time[mu]) > 2:
-                        dsa_ids = numpy.unique(self.ids_at_time[mu][:, 1])
-                        dsb_ids = numpy.unique(self.ids_at_time[mu][:, 2])
-                        _i, _i, dsa_pos_ids = numpy.intersect1d(
-                            self.pos_data[:, 1],
-                            dsa_ids, return_indices=True)
-                        _i, _i, dsb_pos_ids = numpy.intersect1d(
-                            self.pos_data[:, 1],
-                            dsb_ids, return_indices=True)
+                    dsa_ids = numpy.unique(self.ids_at_time[mu][:, 1])
+                    dsb_ids = numpy.unique(self.ids_at_time[mu][:, 2])
+                    _i, _i, dsa_pos_ids = numpy.intersect1d(
+                        self.pos_data[:, 1],
+                        dsa_ids, return_indices=True)
+                    _i, _i, dsb_pos_ids = numpy.intersect1d(
+                        self.pos_data[:, 1],
+                        dsb_ids, return_indices=True)
 
-                        # objects a & b translations
-                        obj_pos_a = self.pos_data[dsa_pos_ids, 2:5]
-                        obj_pos_b = self.pos_data[dsb_pos_ids, 2:5]
+                    # objects a & b translations
+                    obj_pos_a = self.pos_data[dsa_pos_ids, 2:5]
+                    obj_pos_b = self.pos_data[dsb_pos_ids, 2:5]
 
-                        self._all_objs_pos[mu] = numpy.vstack((obj_pos_a,
-                                                               obj_pos_b))
+                    self._all_objs_pos[mu] = numpy.vstack((obj_pos_a,
+                                                           obj_pos_b))
 
-                        self._all_objs_pos_vtk[mu] = numpy_support.numpy_to_vtk(
-                            self._all_objs_pos[mu])
-                        self._objs_points[mu].SetData(self._all_objs_pos_vtk[mu])
+                    self._all_objs_pos_vtk[mu] = numpy_support.numpy_to_vtk(
+                        self._all_objs_pos[mu])
+                    self._objs_points[mu].SetData(self._all_objs_pos_vtk[mu])
 
-                        self._objs_output[mu].GetPointData().AddArray(self.cn[mu])
-                        self._objs_output[mu].GetPointData().AddArray(self.cf[mu])
+                    self._objs_output[mu].GetPointData().AddArray(self.cn[mu])
+                    self._objs_output[mu].GetPointData().AddArray(self.cf[mu])
 
 
                     #if dom_imu is not None:

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -10,7 +10,6 @@ import os
 import json
 import getopt
 import math
-from functools import reduce
 from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase
 from vtk.numpy_interface import dataset_adapter as dsa
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -10,6 +10,7 @@ import os
 import json
 import getopt
 import math
+import traceback
 from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase
 from vtk.numpy_interface import dataset_adapter as dsa
 
@@ -806,7 +807,7 @@ class IOReader(VTKPythonAlgorithmBase):
                             self.ids_at_time[mu] = data[
                                 imu, 23:26].astype(int)
                         else:
-                            self.ids_at_time[mu] = None
+                            self.ids_at_time[mu] = [[nan, nan, nan]]
 
             else:
                 for mu in self._mu_coefs:
@@ -814,7 +815,7 @@ class IOReader(VTKPythonAlgorithmBase):
                     self.cpb_at_time[mu] = [[nan, nan, nan]]
                     self.cn_at_time[mu] =  [[nan, nan, nan]]
                     self.cf_at_time[mu] =  [[nan, nan, nan]]
-                    self.ids_at_time[mu] = None
+                    self.ids_at_time[mu] = [[nan, nan, nan]]
 
             for mu in self._mu_coefs:
                 self.cpa[mu] = numpy_support.numpy_to_vtk(
@@ -852,7 +853,7 @@ class IOReader(VTKPythonAlgorithmBase):
                     self._contact_field[mu].AddArray(self.ids[mu])
                     self._output[mu].GetPointData().AddArray(self.ids[mu])
 
-                    if len(self.ids_at_time[mu][0, :] > 2):
+                    if len(self.ids_at_time[mu]) > 2:
                         dsa_ids = numpy.unique(self.ids_at_time[mu][:, 1])
                         dsb_ids = numpy.unique(self.ids_at_time[mu][:, 2])
                         _i, _i, dsa_pos_ids = numpy.intersect1d(
@@ -886,7 +887,7 @@ class IOReader(VTKPythonAlgorithmBase):
                     #    self._contact_field[mu].AddArray(self.dom[mu])
 
         except Exception as e:
-            print(e)
+            traceback.print_exc()
 
         return 1
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -406,7 +406,8 @@ class CFprov():
         if self._data is not None:
 
             mus, imus = numpy.unique(self._data[:, 1], return_inverse=True)
-                        
+
+            #print('xmethod', self._data[i, 2:5]))
             for i, imu in enumerate(imus):
                 mu = mus[imu]
                 fdata = self._output[mu].GetFieldData()

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -799,19 +799,24 @@ class IOReader(VTKPythonAlgorithmBase):
         t = info.Get(vtk.vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP())
 
         id_t = numpy.searchsorted(self._times, t, side='right') - 1
-        self._id_t_m = range(self._indices[id_t],
-                             self._indices[min(id_t+1, len(self._indices)-1)])
+        if id_t < len(self._indices)-1:
+            self._id_t_m = range(self._indices[id_t],
+                                 self._indices[id_t+1])
+        else:
+            self._id_t_m = [self._indices[id_t]]
         self._time = self._times[id_t]
         self._index = id_t
         
         id_t_cf = numpy.searchsorted(self._cf_times, t, side='right') - 1
-        self._id_t_m_cf = range(self._cf_indices[id_t_cf],
-                                self._cf_indices[min(id_t_cf+1,
-                                                     len(self._cf_indices)-1)])
+        if id_t_cf < len(self._cf_indices)-1:
+            self._id_t_m_cf = range(self._cf_indices[id_t_cf],
+                                    self._cf_indices[id_t_cf+1])
+        else:
+            self._id_t_m_cf = [self._cf_indices[id_t_cf]]
 
         self.pos_data = self._idpos_data[self._id_t_m, :]
         self.velo_data = self._ivelo_data[self._id_t_m, :]
-        self.cf_data = self._icf_data[self._id_t_m_cf, :]
+        #self.cf_data = self._icf_data[self._id_t_m_cf, :]
 
         vtk_pos_data = dsa.numpyTovtkDataArray(self.pos_data)
         vtk_pos_data.SetName('pos_data')
@@ -819,12 +824,12 @@ class IOReader(VTKPythonAlgorithmBase):
         vtk_velo_data = dsa.numpyTovtkDataArray(self.velo_data)
         vtk_pos_data.SetName('velo_data')
 
-        vtk_cf_data = dsa.numpyTovtkDataArray(self.cf_data)
-        vtk_cf_data.SetName('cf_data')
+        #vtk_cf_data = dsa.numpyTovtkDataArray(self.cf_data)
+        #vtk_cf_data.SetName('cf_data')
 
         output.GetFieldData().AddArray(vtk_pos_data)
         output.GetFieldData().AddArray(vtk_velo_data)
-        output.GetFieldData().AddArray(vtk_cf_data)
+        #output.GetFieldData().AddArray(vtk_cf_data)
         
         return 1
         

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -886,7 +886,7 @@ class IOReader(VTKPythonAlgorithmBase):
                     #    self.dom[mu].SetName('domains')
                     #    self._contact_field[mu].AddArray(self.dom[mu])
 
-        except Exception as e:
+        except Exception:
             traceback.print_exc()
 
         return 1

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -395,6 +395,8 @@ class CFprov():
             self._objs_output[mu] = vtk.vtkPolyData()
             self._objs_output[mu].SetPoints(self._objs_points[mu])
 
+        self.xmethod()
+
     def xmethod(self):
         nan = numpy.nan
 

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -509,7 +509,7 @@ class InputObserver():
         self.vview.iter_plot.SetSelection(self._current_id)
         self.vview.prec_plot.SetSelection(self._current_id)
 
-        self.vview.renderer_window.Render()
+#        self.vview.renderer_window.Render()
 
     def set_opacity(self):
         for instance, actors in self.vview.dynamic_actors.items():
@@ -798,7 +798,7 @@ class IOReader(VTKPythonAlgorithmBase):
         # The time step requested
         t = info.Get(vtk.vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP())
 
-        id_t = numpy.searchsorted(self._times, t, side='right') - 1
+        id_t = max(0, numpy.searchsorted(self._times, t, side='right') - 1)
         if id_t < len(self._indices)-1:
             self._id_t_m = range(self._indices[id_t],
                                  self._indices[id_t+1])
@@ -807,7 +807,7 @@ class IOReader(VTKPythonAlgorithmBase):
         self._time = self._times[id_t]
         self._index = id_t
         
-        id_t_cf = numpy.searchsorted(self._cf_times, t, side='right') - 1
+        id_t_cf = max(0, numpy.searchsorted(self._cf_times, t, side='right') - 1)
         if id_t_cf < len(self._cf_indices)-1:
             self._id_t_m_cf = range(self._cf_indices[id_t_cf],
                                     self._cf_indices[id_t_cf+1])
@@ -1752,8 +1752,8 @@ class VView(object):
         self.time0 = None
         try:
             # Positions at first time step
-            self.io_reader.SetTime(0)
             self.time0 = self.io_reader._times[0]
+            self.io_reader.SetTime(self.time0)
             #self.pos_t0 = dsa.WrapDataObject(self.io_reader.GetOutputDataObject(0).GetFieldData().GetArray('pos_data'))
             self.pos_t0 = [self.io_reader.pos_data]
 
@@ -2207,6 +2207,7 @@ from siconos.io.mechanics_hdf5 import MechanicsHdf5
 from siconos.io.mechanics_hdf5 import tmpfile as io_tmpfile
 from siconos.io.mechanics_hdf5 import occ_topo_list, occ_load_file,\
     topods_shape_reader, brep_reader
+
 
 if __name__=='__main__':
     ## Options and config already loaded above

--- a/io/swig/io/vview.py
+++ b/io/swig/io/vview.py
@@ -64,7 +64,11 @@ class VViewOptions(object):
         self.advance_by_time = None
         self.frames_per_second = 25
         self.cf_disable = False
-        self.imr = False
+        if hasattr(vtk.vtkPolyDataMapper(), 'ImmediateModeRenderingOff'):
+            self.imr = False
+        else:
+            # vtk 8
+            self.imr = True
         self.depth_peeling = True
         self.maximum_number_of_peels = 100
         self.occlusion_ratio = 0.1


### PR DESCRIPTION
Some improvements for siconos_vview and siconos_vexport, this is related to #59 and this is a preliminary to #153, this is not fully functional (cf issues below) but I think it should be merged as ``vview.py`` is now affected a lot:

 - the reading is done from a new IOReader class which provides
   slices at the requested time into the hdf5 file,

 - for simplifications, the contact forces provider class is merged
   into this IOReader class,

 - the global-filter option (all vtkPolyData associated to each contactors
   are merged in one big vtkPolyData) is reworked and provides now correct
   associated data : velocity, translation, instance number.
   It is intended to be used with siconos_vexport for paraview visualization.
   It may be set with siconos_vview but it is nearly useless as the process
   is slow.

Issues:

 - IOReader class is piloted as a vtk source but for the moment the
   output data is only used (by VView class) from numpy output
   attributes so, yes, it is weird,

 - from the wish list of #59, contact positions and kinetic energy should be added to associated data,

 - with global-filter option, all objects (statics, dynamics) are at
   the same level in the same block in the output and we can think about
   some separation such as one block for static, and one block for each group ids
   (group ids given for the nonsmooth law specifications).
