### PR TITLE
[io] Fix path and target for serialization headers generation.

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -92,7 +92,7 @@ if(WITH_SERIALIZATION)
 
     ADD_CUSTOM_COMMAND(
       OUTPUT ${GENERATED_HEADER}
-      DEPENDS doxygen ${GENERATED_DEPENDENCIES}
+      DEPENDS kernel_xml4swig ${GENERATED_DEPENDENCIES}
       ${CMAKE_SOURCE_DIR}/io/tools/build_from_doxygen.py
       ${CMAKE_SOURCE_DIR}/io/tools/builder_common.py
       ${GENERATED_COMMAND})
@@ -104,7 +104,7 @@ if(WITH_SERIALIZATION)
 
     ADD_CUSTOM_COMMAND(
       OUTPUT ${GENERATED_HEADER_KERNEL}
-      DEPENDS doxygen ${GENERATED_DEPENDENCIES}
+      DEPENDS kernel_xml4swig ${GENERATED_DEPENDENCIES}
       ${GENERATED_COMMAND_KERNEL})
   endif()
 endif()

--- a/io/tools/build_from_doxygen.py
+++ b/io/tools/build_from_doxygen.py
@@ -47,16 +47,16 @@ def get_classes_conditional(doxy_xml_files, cond):
                     })
     return found
 
-def classes_from_build_path(build_path):
+def classes_from_build_path(build_path, targets):
     """Get classes and members from all Doxygen XML files found on the
        provided build path."""
-    doxy_xml_path = os.path.join(build_path,'Docs/build/html/doxygen/xml')
+    doxy_xml_path = os.path.join(build_path,'docs/build/doxygen/doxy2swig-xml')
     if not os.path.exists(doxy_xml_path):
         print('%s: Error, path "%s" does not exist.'%(sys.argv[0], doxy_xml_path))
         sys.exit(1)
-    doxy_xml_files = (
-        glob(os.path.join(doxy_xml_path, 'class*.xml'))
-        + glob(os.path.join(doxy_xml_path, 'struct*.xml')))
+    doxy_xml_files = [p for t in targets
+                      for p in (glob(os.path.join(doxy_xml_path, '%s/class*.xml'%t))
+                                + glob(os.path.join(doxy_xml_path, '%s/struct*.xml'%t)))]
 
     # We want only classes that contain calls to the
     # ACCEPT_SERIALIZATION macro.
@@ -142,8 +142,7 @@ if __name__=='__main__':
      build_path) = parse_args(need_build_path=True)
 
     all_headers = get_headers(targets)
-
-    doxygen_classes = classes_from_build_path(build_path)
+    doxygen_classes = classes_from_build_path(build_path, targets)
 
     header_classes = classes_from_headers(all_headers, include_paths)
 
@@ -159,7 +158,7 @@ if __name__=='__main__':
     classes = {k: v for k,v in doxygen_classes.items()
                if in_maybe_inner(k, header_classes) and not unwanted(k)}
 
-    print('{:} classes found.'.format(len(classes)))
+    print('{:} classes found for targets {:}.'.format(len(classes), ', '.join(targets)))
 
     if len(classes) < 10:
         print('%s: Error, not enough classes found.'%sys.argv[0])


### PR DESCRIPTION
After some mentions of build problems I thought I would check the status of master.  I am unable to build with serialization turned on.  I also found that generating the serialization headers is broken.

This PR changes the `doxygen` dependency target which has changed I guess.  Probably `kernel_xml4swig` is not correct, maybe someone can suggest a better fix.

However, I think the patch to `build_common.py` is necessary.

Unfortunately even with this, I get errors in `kernelPYTHON_wrap.cxx` trying to build with serialization, but I cannot figure them out.

Many errors like this:

```
/usr/include/boost/serialization/access.hpp:116:11: error: ‘class LinearOSNS’ has no member named ‘serialize’; did you mean ‘serializable’?
```

which seems like the classes do not have serialization declared but it's weird because `SiconosFullGenerated.hpp` is definitely getting included, I used `#error` to check.  However I noticed that the generated headers have a lot of things re-ordered, which is supposed to be avoided by sorting them by priority and by name in `io/tools/build_from_doxygen.py`, but it seems to have decided to move a lot of things around so it's hard to tell if this is due to registration order.