### PR TITLE
Mechanics run fixes pr

### DIFF
--- a/io/swig/io/mechanics_run.py
+++ b/io/swig/io/mechanics_run.py
@@ -1914,6 +1914,9 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
             options.minimumPointsPerturbationThreshold = 3*multipoints_iterations
         self._interman = interaction_manager(options)
 
+        if hasattr(self._interman, 'useEqualityConstraints') and len(joins)==0:
+            self._interman.useEqualityConstraints(False)
+
         # (0) NonSmooth Dynamical Systems definition
         self._nsds=NonSmoothDynamicalSystem(t0, T)
         nsds=self._nsds

--- a/io/swig/io/mechanics_run.py
+++ b/io/swig/io/mechanics_run.py
@@ -1397,12 +1397,29 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
         # import dynamical systems
         if self._interman is not None and 'input' in self._data:
 
+            # get pointers
             dpos_data = self.dynamic_data()
+            velocities = self.velocities_data()
+
+            # some dict to prefetch values in order to
+            # speedup cold start in the case of many objects
+            xdpos_data = dict()
+            xvelocities = dict()
+
             if dpos_data is not None and len(dpos_data) > 0:
 
                 max_time = max(dpos_data[:, 0])
                 id_last = np.where(
                     abs(dpos_data[:, 0] - max_time) < 1e-9)[0]
+                id_vlast = np.where(
+                            abs(velocities[:, 0] - max_time) < 1e-9)[0]
+
+                # prefetch positions and velocities in dictionaries
+                # this avoids calls to np.where for each object
+                for ldpos_data in dpos_data[id_last, :]:
+                    xdpos_data[ldpos_data[1]] = ldpos_data
+                for lvelocities in velocities[id_vlast, :]:
+                    xvelocities[lvelocities[1]] = lvelocities
 
             else:
                 # should not be used
@@ -1432,30 +1449,23 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
                     if (mass is not None and mass > 0
                         and dpos_data is not None and len(dpos_data) > 0):
 
-                        self.print_verbose ('Import  dynamic object name ', name,
-                                            'from current state')
-                        self.print_verbose ('imported object has id: {0}'.format(obj.attrs['id']))
+                        self.print_verbose('Import  dynamic object name ',
+                                           name,
+                                           'from current state')
+                        self.print_verbose('imported object has id: {0}'.
+                                           format(obj.attrs['id']))
 
-                        id_last_inst = np.where(
-                            dpos_data[id_last, 1] ==
-                            self.instances()[name].attrs['id'])[0]
-                        xpos = dpos_data[id_last[id_last_inst[0]], :]
+                        xpos = xdpos_data[obj.attrs['id']]
                         translation = (xpos[2], xpos[3], xpos[4])
                         orientation = (xpos[5], xpos[6], xpos[7], xpos[8])
 
-                        velocities = self.velocities_data()
-                        id_vlast = np.where(
-                            abs(velocities[:, 0] - max_time) < 1e-9)[0]
-
-                        id_vlast_inst = np.where(
-                            velocities[id_vlast, 1] ==
-                            self.instances()[name].attrs['id'])[0]
-                        xvel = velocities[id_vlast[id_vlast_inst[0]], :]
+                        xvel = xvelocities[obj.attrs['id']]
                         velocity = (xvel[2], xvel[3], xvel[4],
                                     xvel[5], xvel[6], xvel[7])
 
-                        self.print_verbose ('position:', list(translation)+list(orientation))
-                        self.print_verbose ('velocity:',  velocity)
+                        self.print_verbose('position:', list(translation) +
+                                           list(orientation))
+                        self.print_verbose('velocity:',  velocity)
 
 
                     else:

--- a/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
+++ b/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
@@ -1615,7 +1615,7 @@ void SiconosBulletCollisionManager::updateInteractions(SP::Simulation simulation
     // relation (e.g. EqualityCondition == they have a joint between
     // them), then don't create contact constraints, because it leads
     // to an ill-conditioned problem.
-    if (pairA->ds && pairB->ds)
+    if (_with_equality_constraints && pairA->ds && pairB->ds)
     {
       InteractionsGraph::VIterator ui, uiend;
       SP::InteractionsGraph indexSet0 = simulation->nonSmoothDynamicalSystem()->topology()->indexSet0();

--- a/mechanics/src/collision/bullet/SiconosBulletCollisionManager.hpp
+++ b/mechanics/src/collision/bullet/SiconosBulletCollisionManager.hpp
@@ -79,6 +79,7 @@ public:
   virtual ~SiconosBulletCollisionManager();
 
 protected:
+  bool _with_equality_constraints;
   SiconosBulletOptions _options;
   SiconosBulletStatistics _stats;
 
@@ -113,6 +114,15 @@ public:
   const SiconosBulletOptions &options() const { return _options; }
   const SiconosBulletStatistics &statistics() const { return _stats; }
   void resetStatistics() { _stats = SiconosBulletStatistics(); }
+
+  /** Set the usage of equality constraints. When the number
+      of objects is huge as in granular material, the usage
+      of equality constraint breaks scalability.
+      This have to be fixed.
+   * \param choice a boolean, default is True.
+   */
+  void useEqualityConstraints(bool choice=true)
+  { _with_equality_constraints = choice; };
 };
 
 #endif /* SiconosBulletCollisionManager.hpp */


### PR DESCRIPTION
This pull request is meant to:

 - improve scalability of siconos/bullet collision manager whith many
   contacts and without bilateral constraints,

 - speedup cold restart with many object with a prefetch of position
   and velocities to avoid time consuming search for each objects in
   hdf5 file.

For what concerns the collision manager, here is a perf report of
several steps of a simulation with 10K spheres in a box when the
number of contacts reach ~16K

```
Samples: 2M of event 'cycles:ppp', Event count (approx.): 1935907399383                                                                               
  Children      Self  Command  Shared Object                                      Symbol                                                             +
-   27.63%     0.00%  python3  libsiconos_kernel.so.6.0.0                         [.] Simulation::updateInteractions                                 :
   - Simulation::updateInteractions                                                                                                                  :
        22.35% SiconosBulletCollisionManager::updateInteractions                                                                                     :
        2.83% std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release                                                                          :
        2.22% __dynamic_cast                                                                                                                         :
+   22.35%    22.31%  python3  libsiconos_mechanics.so.6.0.0                      [.] SiconosBulletCollisionManager::updateInteractions              :
+   21.49%    21.46%  python3  libsiconos_numerics.so.6.0.0                       [.] SBM_row_prod_no_diag_3x3                                       :
+   14.48%     0.00%  python3  [unknown]                                          [.] 0x0000000002cefc00                                             :
+   13.16%     0.00%  python3  [unknown]                                          [.] 0x00000000009d0460                                             :
+   12.60%     0.00%  python3  [unknown]                                          [.] 0x0000000042a847e0                                             :
+    9.92%     9.90%  python3  libsiconos_numerics.so.6.0.0                       [.] fc3d_onecontact_nonsmooth_Newton_solvers_solve_damped          :
+    5.67%     0.00%  python3  [unknown]                                          [.] 0x0000000037d8cba0                                             :
+    5.62%     1.85%  python3  libsiconos_numerics.so.6.0.0                       [.] numerics_printf_verbose                                        :
+    5.62%     5.61%  python3  libm-2.27.so                                       [.] __hypot_finite                                                 :
+    5.19%     5.18%  python3  libsiconos_numerics.so.6.0.0                       [.] computeAlartCurnierSTD                                         :
```

Note that the time spent in the collision manager is more than the one
spent in the solver, which is not the case for small simulations (<1K
contacts).

In the collision manager a loop is done over all bullet contacts and
then a research is made for each contact over the whole indexSet0 to
see if the contacts is not an equality relation.  This cannot scale.

Obviously, with granular simulation, joints may not be needed. And if
they are ever needed their number would be much smaller than the
number of dynamical systems in the simulation.  A solution would be to
store the dynamical systems which are concerned by joints somewhere in
the BulletCollsionManager, and to iterate over this list.

I simply add a flag which is set from ```mechanics_run.py``` if the
number of joints is 0 and this improve the situation.

```c++
for (it=t.begin(); it!=itend; ++it)
  {
    DEBUG_PRINTF("  -- %p, %p, %p\n", it->objectA, it->objectB, it->point);

    // Get the RigidBodyDS and SiconosShape pointers

    const BodyShapeRecord *pairA, *pairB;
    pairA = reinterpret_cast<const BodyShapeRecord*>(it->objectA->getUserPointer());
    pairB = reinterpret_cast<const BodyShapeRecord*>(it->objectB->getUserPointer());
    assert(pairA && pairB && "btCollisionObject had a null user pointer!");

    // The first pair will always be the non-static object
    bool flip = false;
    if (pairB->ds && !pairA->ds) {
      pairA = reinterpret_cast<const BodyShapeRecord*>(it->objectB->getUserPointer());
      pairB = reinterpret_cast<const BodyShapeRecord*>(it->objectA->getUserPointer());
      flip = true;
    }

    // If both collision objects belong to the same body (or no body),
    // no interaction is created.
    if (pairA->ds == pairB->ds)
      continue;

    // If the two bodies are already connected by another type of
    // relation (e.g. EqualityCondition == they have a joint between
    // them), then don't create contact constraints, because it leads
    // to an ill-conditioned problem.
    if (pairA->ds && pairB->ds)
    {
      InteractionsGraph::VIterator ui, uiend;
      SP::InteractionsGraph indexSet0 = simulation->nonSmoothDynamicalSystem()->topology()->indexSet0();
      bool match = false;
      for (std11::tie(ui, uiend) = indexSet0->vertices(); ui != uiend; ++ui)
      {
        SP::Interaction inter( indexSet0->bundle(*ui) );
```

this check is transformed in

```c++

    if (_with_equality_constraints && pairA->ds && pairB->ds)

```