### PR TITLE
Some valgrind fixes for gfc3d admm (work in progress)

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -12,7 +12,7 @@ set(CTEST_NIGHTLY_START_TIME "20:00:00 CET")
 # https is needed on cdash server side
 set(CTEST_DROP_METHOD "https")
 #set(CTEST_DROP_SITE "my.cdash.org/")
-set(CTEST_DROP_SITE "cdash-tripop.inrialpes.fr")
+set(CTEST_DROP_SITE "cdash-ci.inria.fr")
 set(CTEST_DROP_LOCATION "/submit.php?project=Siconos")
 set(CTEST_DROP_SITE_CDASH TRUE)
 if(BUILD_NAME)

--- a/numerics/src/FrictionContact/gfc3d_admm.c
+++ b/numerics/src/FrictionContact/gfc3d_admm.c
@@ -97,6 +97,7 @@ void gfc3d_ADMM_free(GlobalFrictionContactProblem* problem, SolverOptions* optio
     free(data->reaction_hat);
     free(data->u_hat);
     free(data->reaction_k);
+    free(data->u);
     free(data->u_k);
     free(data->b_full);
     if  (options->iparam[SICONOS_FRICTION_3D_ADMM_IPARAM_FULL_H] ==
@@ -226,6 +227,7 @@ static inline void gfc3d_ADMM_compute_full_H(int nc, double * u,
   //DEBUG_EXPR(NM_display(H));
   NM_gemm(1.0, H, H_correction, 0.0, H_full);
   NM_free(H_correction);
+  free(H_correction);
 
   DEBUG_EXPR(NM_display(H_full));
   DEBUG_END("gfc3d_ADMM_compute_H_correction(...)\n");
@@ -326,10 +328,13 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   double tolerance = dparam[0];
 
   /* Check for trivial case */
-  *info = gfc3d_checkTrivialCaseGlobal(n, q, velocity, reaction, globalVelocity, options);
-
-  if (*info == 0)
+  if(!gfc3d_checkTrivialCaseGlobal(n, q, velocity, reaction, globalVelocity, options))
+  {
+    NM_free(Htrans);
+    free(Htrans);
+    free(W);
     return;
+  }
 
   double norm_q = cblas_dnrm2(n , q , 1);
 
@@ -361,7 +366,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
     {
       numerics_printf_verbose(1,"---- GFC3D - ADMM -  M is not symmetric");
     }
-    
+
     NM_free(W);
   }
 
@@ -545,6 +550,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
         }
         else
         {
+          NM_free(W);
           NM_copy(M, W);
           NM_gemm(rho, H, Htrans, 1.0, W);
         }
@@ -887,6 +893,11 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   /***** Free memory *****/
   NM_free(W);
   NM_free(Htrans);
+  NM_free(H_full);
+  free(W);
+  free(Htrans);
+  free(H_full);
+
   if (internal_allocation)
   {
     gfc3d_ADMM_free(problem,options);

--- a/numerics/src/FrictionContact/gfc3d_admm.c
+++ b/numerics/src/FrictionContact/gfc3d_admm.c
@@ -582,9 +582,12 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
       }
       else
       {
-        /* NM_gesv_expert(W,v,NM_KEEP_FACTORS); */
         NSM_linear_solver_params* p = NSM_linearSolverParams(W);
-        p->solver =  NSM_CS_CHOLSOL;
+#ifdef WITH_MUMPS
+        p->solver = NSM_MUMPS;
+#else
+        p->solver = NSM_CS_CHOLSOL;
+#endif
         NM_posv_expert(W,v,NM_KEEP_FACTORS);
       }
       DEBUG_PRINT("v:");

--- a/numerics/src/FrictionContact/test-utils/globalFrictionContact_test_function.c
+++ b/numerics/src/FrictionContact/test-utils/globalFrictionContact_test_function.c
@@ -195,6 +195,7 @@ int gfc3d_test_function_hdf5(const char* path, SolverOptions* options)
       }
       printf("path_copy = %s \n", path_copy);
     }
+    free(path_copy);
 
     char * path_out = (char *)calloc((nLen+10), sizeof(char));
     sprintf(path_out, "%s.dat", path); /* finally we keep the extension .hdf5.dat */
@@ -202,6 +203,7 @@ int gfc3d_test_function_hdf5(const char* path, SolverOptions* options)
     FILE * foutput  =  fopen(path_out, "w");
     info = globalFrictionContact_printInFile(problem, foutput);
     fclose(foutput);
+    free(path_out);
   }
 
 

--- a/numerics/src/FrictionContact/test/gfc3d_test_collection.c.in
+++ b/numerics/src/FrictionContact/test/gfc3d_test_collection.c.in
@@ -315,6 +315,11 @@ static int gfc_test(char ** test)
 
     }
 
+    free(failed_tests);
+    free(succeeded_tests);
+    free(_data_collection);
+    free(_test_collection);
+
 #ifdef SICONOS_HAS_MPI
     MPI_Finalize();
 #endif

--- a/numerics/src/tools/CSparseMatrix.c
+++ b/numerics/src/tools/CSparseMatrix.c
@@ -485,10 +485,7 @@ CS_INT CSparseMatrix_symmetric_zentry(CSparseMatrix *T, CS_INT i, CS_INT j, doub
       return cs_entry(T, i, j, x);
     }
   }
-  else
-  {
-    return 1;
-  }
+  return 1;
 }
 
 

--- a/numerics/src/tools/CSparseMatrix.c
+++ b/numerics/src/tools/CSparseMatrix.c
@@ -474,6 +474,24 @@ CS_INT CSparseMatrix_zentry(CSparseMatrix *T, CS_INT i, CS_INT j, double x)
     return 1;
   }
 }
+
+/* add an entry to a symmetric triplet matrix only if value is not (nearly) null */
+CS_INT CSparseMatrix_symmetric_zentry(CSparseMatrix *T, CS_INT i, CS_INT j, double x)
+{
+  if(fabs(x) >= DBL_EPSILON)
+  {
+    if (j<=i)
+    {
+      return cs_entry(T, i, j, x);
+    }
+  }
+  else
+  {
+    return 1;
+  }
+}
+
+
 int CSparseMatrix_print_in_file(const CSparseMatrix *A, int brief, FILE* file)
 {
   CS_INT m, n, nzmax, nz, p, j, *Ap, *Ai ;

--- a/numerics/src/tools/CSparseMatrix.h
+++ b/numerics/src/tools/CSparseMatrix.h
@@ -214,6 +214,17 @@ extern "C"
    */
   CS_INT CSparseMatrix_zentry(CSparseMatrix *T, CS_INT i, CS_INT j, double x);
 
+  /** Add an entry to a symmetric triplet matrix only if the absolute value is
+   * greater than DBL_EPSILON.
+   * \param T the sparse matrix
+   * \param i row index
+   * \param j column index
+   * \param x the value
+   * \return integer value : 1 if the absolute value is less than
+   * DBL_EPSILON, otherwise the return value of cs_entry.
+   */
+  CS_INT CSparseMatrix_symmetric_zentry(CSparseMatrix *T, CS_INT i, CS_INT j, double x);
+
   /** Check if the given triplet matrix is properly constructed (col and row indices are correct)
    * \param T the sparse matrix to check
    * \return 0 if the matrix is fine, 1 otherwise

--- a/numerics/src/tools/NM_conversions.c
+++ b/numerics/src/tools/NM_conversions.c
@@ -53,6 +53,24 @@ CSparseMatrix* NM_csc_to_triplet(CSparseMatrix* csc)
   return triplet;
 }
 
+CSparseMatrix* NM_csc_to_half_triplet(CSparseMatrix* csc)
+{
+  assert(csc);
+  CSparseMatrix* triplet = cs_spalloc(csc->m, csc->n, csc->p[csc->n], 1, 1);
+  if (!triplet) return (cs_done (triplet, NULL, NULL, 0)) ;
+  CS_INT* Ap = csc->p;
+  CS_INT* Ai = csc->i;
+  double* val = csc->x;
+  for (CS_INT j = 0; j < csc->n; ++j)
+  {
+    for (CS_INT i = Ap[j]; i < Ap[j+1]; ++i)
+    {
+      CSparseMatrix_symmetric_zentry(triplet, Ai[i], j, val[i]);
+    }
+  }
+  return triplet;
+}
+
 CSparseMatrix* NM_triplet_to_csr(CSparseMatrix* triplet)
 {
 #ifdef WITH_MKL_SPBLAS

--- a/numerics/src/tools/NM_conversions.h
+++ b/numerics/src/tools/NM_conversions.h
@@ -34,6 +34,12 @@ extern "C"
    */
   CSparseMatrix* NM_csc_to_triplet(CSparseMatrix* csc);
 
+  /** Convert from csc to half triplet for symmetric matrices
+   * \param csc the matrix to convert
+   * \return the matrix in triplet format
+   */
+  CSparseMatrix* NM_csc_to_half_triplet(CSparseMatrix* csc);
+
   /** Convert from triplet (aka coo) to csr
    * \param triplet the matrix to convert
    * \return the matrix in csr format

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -3599,41 +3599,13 @@ double NM_norm_1(NumericsMatrix* A)
 double NM_norm_inf(NumericsMatrix* A)
 {
   assert(A);
-
-
-  switch (A->storageType)
-  {
-  case NM_DENSE:
-  {
-    assert(A->storageType == NM_DENSE);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  case NM_SPARSE_BLOCK:
-  {
-    assert(A->storageType == NM_SPARSE_BLOCK);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  case NM_SPARSE:
-  {
-    assert(A->storageType == NM_SPARSE);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  default:
-    {
-      assert(0 && "NM_norm unknown storageType");
-    }
-  }
-  return NAN;
+  CSparseMatrix* Acsct = cs_transpose(NM_csc(A), 1);
+  double norm = cs_norm(Acsct);
+  assert(norm >=0);
+  cs_spfree(Acsct);
+  return norm;
 }
+
 int NM_is_symmetric(NumericsMatrix* A)
 {
 
@@ -3643,7 +3615,7 @@ int NM_is_symmetric(NumericsMatrix* A)
   double norm_inf = NM_norm_inf(AplusATrans);
   NM_free(Atrans); free(Atrans);
   NM_free(AplusATrans);  free(AplusATrans);
-  
+
   if (norm_inf <= DBL_EPSILON*10)
   {
     return 1;

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -2871,6 +2871,17 @@ int NM_gesv_expert(NumericsMatrix* A, double *b, unsigned keep)
         /* the mumps instance is initialized (call with job=-1) */
         NM_MUMPS_set_control_params(A);
         NM_MUMPS(A, -1);
+        if ((NM_MUMPS_icntl(A, 1) == -1 ||
+             NM_MUMPS_icntl(A, 2) == -1 ||
+             NM_MUMPS_icntl(A, 3) == -1 ||
+             verbose) ||
+            (NM_MUMPS_icntl(A, 1) != -1 ||
+             NM_MUMPS_icntl(A, 2) != -1 ||
+             NM_MUMPS_icntl(A, 3) != -1 ||
+             !verbose))
+        {
+          NM_MUMPS_set_verbosity(A, verbose);
+        }
         NM_MUMPS_set_icntl(A, 24, 1); // Null pivot row detection
         NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value
       }
@@ -3231,6 +3242,18 @@ int NM_posv_expert(NumericsMatrix* A, double *b, unsigned keep)
         NM_MUMPS_set_control_params(A);
         NM_MUMPS_set_sym(A, 2); /* general symmetric */
         NM_MUMPS(A, -1);
+        if ((NM_MUMPS_icntl(A, 1) == -1 ||
+             NM_MUMPS_icntl(A, 2) == -1 ||
+             NM_MUMPS_icntl(A, 3) == -1 ||
+             verbose) ||
+            (NM_MUMPS_icntl(A, 1) != -1 ||
+             NM_MUMPS_icntl(A, 2) != -1 ||
+             NM_MUMPS_icntl(A, 3) != -1 ||
+             !verbose))
+        {
+          NM_MUMPS_set_verbosity(A, verbose);
+        }
+
         NM_MUMPS_set_icntl(A, 24, 1); // Null pivot row detection
         NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value
       }

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -3229,7 +3229,7 @@ int NM_posv_expert(NumericsMatrix* A, double *b, unsigned keep)
       {
         /* the mumps instance is initialized (call with job=-1) */
         NM_MUMPS_set_control_params(A);
-        NM_MUMPS_set_sym(A, 1);
+        NM_MUMPS_set_sym(A, 2); /* general symmetric */
         NM_MUMPS(A, -1);
         NM_MUMPS_set_icntl(A, 24, 1); // Null pivot row detection
         NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value

--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -156,6 +156,12 @@ extern "C"
    */
   CSparseMatrix* NM_triplet(NumericsMatrix* A);
 
+   /** Creation, if needed, of half triplet storage from sparse block storage.
+   * \param[in,out] A a NumericsMatrix initialized with sparsed block storage.
+   * \return the triplet sparse Matrix created in A.
+   */
+  CSparseMatrix* NM_half_triplet(NumericsMatrix* A);
+
   /** Creation, if needed, of compress column storage of a NumericsMatrix.
    * \param[in,out] A a NumericsMatrix with sparse block storage initialized
    * \return the compressed column CSparseMatrix created in A.
@@ -551,6 +557,11 @@ extern "C"
    * \param[in,out] A a Numericsmatrix
    */
   void NM_clearTriplet(NumericsMatrix* A);
+
+  /** Clear half triplet storage, if it is existent.
+   * \param[in,out] A a Numericsmatrix
+   */
+  void NM_clearHalfTriplet(NumericsMatrix* A);
 
   /** Clear compressed column storage, if it is existent.
    * \param[in,out] A a Numericsmatrix

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -72,6 +72,7 @@ void NSM_null(NumericsSparseMatrix* A)
 {
   A->linearSolverParams = NULL;
   A->triplet = NULL;
+  A->half_triplet = NULL;
   A->csc = NULL;
   A->trans_csc = NULL;
   A->csr = NULL;
@@ -99,6 +100,12 @@ double* NSM_data(NumericsSparseMatrix* A)
   {
     assert(A->triplet);
     return A->triplet->x;
+    break;
+  }
+  case NSM_HALF_TRIPLET:
+  {
+    assert(A->half_triplet);
+    return A->half_triplet->x;
     break;
   }
   default:
@@ -129,6 +136,11 @@ NumericsSparseMatrix* NSM_free(NumericsSparseMatrix* A)
   {
     cs_spfree(A->triplet);
     A->triplet = NULL;
+  }
+  if (A->half_triplet)
+  {
+    cs_spfree(A->half_triplet);
+    A->half_triplet = NULL;
   }
   if (A->csc)
   {
@@ -363,6 +375,8 @@ CSparseMatrix* NSM_get_origin(const NumericsSparseMatrix* M)
     return M->csc;
   case NSM_TRIPLET:
     return M->triplet;
+  case NSM_HALF_TRIPLET:
+    return M->half_triplet;
   case NSM_CSR:
     return M->csr;
   default:

--- a/numerics/src/tools/NumericsSparseMatrix.h
+++ b/numerics/src/tools/NumericsSparseMatrix.h
@@ -75,7 +75,7 @@ extern "C"
 
   /**\enum NumericsSparseOrigin NumericsSparseMatrix.h
    * matrix storage types */
-  typedef enum { NSM_UNKNOWN, NSM_TRIPLET, NSM_CSC, NSM_CSR } NumericsSparseOrigin;
+  typedef enum { NSM_UNKNOWN, NSM_TRIPLET, NSM_CSC, NSM_CSR, NSM_HALF_TRIPLET } NumericsSparseOrigin;
 
 
   /** \struct NumericsSparseMatrix NumericsSparseMatrix.h
@@ -84,6 +84,7 @@ extern "C"
   struct NumericsSparseMatrix
   {
     CSparseMatrix* triplet;    /**< triplet format, aka coordinate */
+    CSparseMatrix* half_triplet;    /**< halt triplet format for symmetric matrices */
     CSparseMatrix* csc;        /**< csc matrix */
     CSparseMatrix* trans_csc;  /**< transpose of a csc matrix (used by CSparse) */
     CSparseMatrix* csr;        /**< csr matrix, only supported with mkl */

--- a/numerics/src/tools/test/NM_MUMPS_test.c
+++ b/numerics/src/tools/test/NM_MUMPS_test.c
@@ -3,7 +3,7 @@
 #include "NumericsSparseMatrix.h"
 #include "NM_MUMPS.h"
 #include "NM_MPI.h"
-#define SIZE 2
+#define SIZE 3
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef SICONOS_HAS_MPI
@@ -12,6 +12,7 @@
 #include <math.h>
 int main(int argc, char *argv[])
 {
+  int rval = 0;
   double b[SIZE];
 
 #ifdef SICONOS_HAS_MPI
@@ -25,8 +26,10 @@ int main(int argc, char *argv[])
 #else
   rank = 0;
 #endif
+  NumericsMatrix* M;
 
-  NumericsMatrix* M = NM_create(NM_SPARSE, SIZE, SIZE);
+  /* unsymmetric test */
+  M = NM_create(NM_SPARSE, 2, 2);
 
 #ifdef SICONOS_HAS_MPI
   NM_MPI_set_comm(M, MPI_COMM_WORLD);
@@ -36,51 +39,105 @@ int main(int argc, char *argv[])
   M->matrix2->origin = NSM_TRIPLET;
 
   NM_MUMPS(M, -1);
+
+  if(rank == 0)
+  {
+    assert (rank == 0);
+    NM_MUMPS_set_verbosity(M, 1);
+
+    /*
+      2*x - y = 1
+      x   + y = 1
+    */
+    /* solution x: 2/3, y: 1/3 */
+
+    NM_zentry(M, 0, 0, 2.);
+    NM_zentry(M, 0, 1, -1.);
+    NM_zentry(M, 1, 0, 1.);
+    NM_zentry(M, 1, 1, 1.);
+
+    for(unsigned int i=0; i<2; ++i)
+    {
+      b[i] = 1.;
+    }
+
+    NM_MUMPS_set_problem(M, b);
+    NM_MUMPS(M, 6);
+    NM_MUMPS(M, -2);
+    NM_MUMPS(M, 0);
+
+    for (unsigned int i=0; i<2; ++i)
+    {
+      printf("solution b[%u] = %g\n", i, b[i]);
+    }
+
+    rval += (fabs(b[0] - 2./3.) > 1e-7);
+    rval = rval << (fabs(b[1] - 1./3.) > 1e-7);
+
+  }
+
+  NM_free(M);
+
+  /* symmetric test */
+  M = NM_create(NM_SPARSE, 3, 3);
+
 #ifdef SICONOS_HAS_MPI
-  if(rank > 0)
-  {
-    MPI_Finalize();
-    NM_free(M);
-    exit(0);
-  }
+  NM_MPI_set_comm(M, MPI_COMM_WORLD);
 #endif
+  NM_MUMPS_set_control_params(M);
+  NM_triplet_alloc(M, 0);
+  M->matrix2->origin = NSM_TRIPLET;
+  NM_MUMPS_set_sym(M, 1);
 
-  assert (rank == 0);
-  NM_MUMPS_set_verbosity(M, 1);
+  NM_MUMPS(M, -1);
 
-  /*
-     2*x - y = 1
-     x   + y = 1
-  */
-  /* solution x: 2/3, y: 1/3 */
-
-  NM_zentry(M, 0, 0, 2.);
-  NM_zentry(M, 0, 1, -1.);
-  NM_zentry(M, 1, 0, 1.);
-  NM_zentry(M, 1, 1, 1.);
-
-  for(unsigned int i=0; i<SIZE; ++i)
+  if(rank == 0)
   {
-    b[i] = 1.;
+    assert (rank == 0);
+    NM_MUMPS_set_verbosity(M, 1);
+
+    /*
+      M=[[1, 0, 0],
+         [0, 1, .5],
+         [0, .5, 1]]
+
+      b=[1, 1, 1]
+    */
+    /* solution: [1, 2/3, 2/3] */
+
+    NM_zentry(M, 0, 0, 1.);
+    NM_zentry(M, 1, 1, 1.);
+    NM_zentry(M, 2, 1, 0.5);
+/*    NM_zentry(M, 1, 2, 0.5);*/
+    NM_zentry(M, 2, 2, 1.);
+
+/*    NM_display(M);*/
+
+    for(unsigned int i=0; i<3; ++i)
+    {
+      b[i] = 1.;
+    }
+
+    NM_MUMPS_set_problem(M, b);
+    NM_MUMPS(M, 6);
+    NM_MUMPS(M, -2);
+    NM_MUMPS(M, 0);
+
+    for (unsigned int i=0; i<3; ++i)
+    {
+      printf("solution b[%u] = %g\n", i, b[i]);
+    }
+
+    rval = rval << (fabs(b[0] - 1.) > 1e-7);
+    rval = rval << (fabs(b[1] - 2./3.) > 1e-7);
+    rval = rval << (fabs(b[2] - 2./3.) > 1e-7);
   }
 
-  NM_MUMPS_set_problem(M, b);
-  NM_MUMPS(M, 6);
-  NM_MUMPS(M, -2);
-  NM_MUMPS(M, 0);
 
-  for (unsigned int i=0; i<SIZE; ++i)
-  {
-    printf("solution b[%u] = %g\n", i, b[i]);
-  }
-
+/*   NM_free(M); */
 #ifdef SICONOS_HAS_MPI
   MPI_Finalize();
 #endif
-  NM_free(M);
 
-  if (fabs(b[0] - 2./3.) > 1e-7) return(1);
-  if (fabs(b[1] - 1./3.) > 1e-7) return(1);
-
-  return(0);
+  return(rval);
 }


### PR DESCRIPTION
On big problems (such as `spheres-in-a-box-39998-i10000-115560-13.hdf5`one can see the memory increase with a simple `top` command.
This a work in progress as there is still leaks, for example with the usage of `NM_transpose`, cf `Htrans.` I still do not understand why it is not freed.

Many errors come from the fact that `NM_free` does not free the pointer! I Propose to rename
`NM_free` and `NSM_free` to `NM_clear` and `NSM_clear.`