### PR TITLE
Some valgrind fixes for numerics and gfc3d admm

### DIFF
--- a/numerics/src/AVI/AffineVariationalInequalities.c
+++ b/numerics/src/AVI/AffineVariationalInequalities.c
@@ -115,7 +115,7 @@ void freeAVI(AffineVariationalInequalities* avi)
   assert(avi);
   if (avi->M)
   {
-    NM_free(avi->M);
+    NM_clear(avi->M);
     free(avi->M);
     avi->M = NULL;
   }

--- a/numerics/src/AVI/avi_caoferris.c
+++ b/numerics/src/AVI/avi_caoferris.c
@@ -235,7 +235,7 @@ int avi_caoferris(AffineVariationalInequalities* problem, double *z, double *w, 
   free(B_I_T);
   free(copyA);
   free(B_A_T);
-  NM_free(lcplike_pb.M);
+  NM_clear(lcplike_pb.M);
   free(lcplike_pb.q);
   free(a_bar);
 

--- a/numerics/src/FrictionContact/FrictionContactProblem.c
+++ b/numerics/src/FrictionContact/FrictionContactProblem.c
@@ -161,7 +161,7 @@ void frictionContactProblem_free(FrictionContactProblem* problem)
   assert(problem);
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = NULL;
   }

--- a/numerics/src/FrictionContact/GlobalFrictionContactProblem.c
+++ b/numerics/src/FrictionContact/GlobalFrictionContactProblem.c
@@ -125,14 +125,14 @@ void globalFrictionContact_free(GlobalFrictionContactProblem* problem)
 
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = NULL;
   }
 
   if (problem->H)
   {
-    NM_free(problem->H);
+    NM_clear(problem->H);
     free(problem->H);
     problem->H = NULL;
   }

--- a/numerics/src/FrictionContact/RollingFrictionContactProblem.c
+++ b/numerics/src/FrictionContact/RollingFrictionContactProblem.c
@@ -177,7 +177,7 @@ void rollingFrictionContactProblem_free(RollingFrictionContactProblem* problem)
   assert(problem);
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = NULL;
   }

--- a/numerics/src/FrictionContact/fc3d_AVI_gams.c
+++ b/numerics/src/FrictionContact/fc3d_AVI_gams.c
@@ -1106,9 +1106,9 @@ TERMINATE:
 
   optFree(&Optr);
   optFree(&solverOptPtr);
-  NM_free(&Wtmat);
-  NM_free(&Emat);
-  NM_free(&Akmat);
+  NM_clear(&Wtmat);
+  NM_clear(&Emat);
+  NM_clear(&Akmat);
 
   free(reaction_old);
   free(velocity_old);

--- a/numerics/src/FrictionContact/fc3d_admm.c
+++ b/numerics/src/FrictionContact/fc3d_admm.c
@@ -249,7 +249,7 @@ static void fc3d_admm_symmetric(FrictionContactProblem* restrict problem,
 
     if (has_rho_changed)
     {
-      /* NM_free(W); */
+      /* NM_clear(W); */
       /* W= NM_new(); */
       NM_copy(M,W);
       NM_add_to_diag3(W, rho);
@@ -527,7 +527,7 @@ static void fc3d_admm_symmetric(FrictionContactProblem* restrict problem,
     }
     numerics_printf_verbose(1,"---- FC3D - ADMM  - Iteration %i rho = %14.7e \t full error = %14.7e", iter, rho, error);
   }
-  NM_free(W);
+  NM_clear(W);
   dparam[SICONOS_DPARAM_RESIDU] = error;
   iparam[SICONOS_IPARAM_ITER_DONE] = iter;
 }
@@ -608,7 +608,7 @@ static void fc3d_admm_asymmetric(FrictionContactProblem* restrict problem,
   /* if (M->storageType == NM_DENSE) */
   /* { */
   /*   NM_copy(A,_A); */
-  /*   NM_free(A); */
+  /*   NM_clear(A); */
   /*   NM_to_dense(_A,A); */
   /* } */
   /* DEBUG_EXPR(NM_display(A);); */
@@ -618,7 +618,7 @@ static void fc3d_admm_asymmetric(FrictionContactProblem* restrict problem,
   /*  cost Matrix */
   NumericsMatrix *M_T = NM_transpose(M);
   NumericsMatrix *M_s = NM_add(1.0, M, 1.0, M_T);
-  NM_free(M_T);
+  NM_clear(M_T);
   DEBUG_EXPR(NM_display(M););
   DEBUG_EXPR(NM_display(M_s););
 
@@ -660,7 +660,7 @@ static void fc3d_admm_asymmetric(FrictionContactProblem* restrict problem,
 
     if (has_rho_changed)
     {
-      /* NM_free(W); */
+      /* NM_clear(W); */
       /* W= NM_new(); */
       NM_copy(M_s,W);
       NM_gemm(rho, Atrans, A, 1.0, W);
@@ -917,7 +917,7 @@ static void fc3d_admm_asymmetric(FrictionContactProblem* restrict problem,
     numerics_printf_verbose(1,"---- FC3D - ADMM  - Iteration %i rho = %14.7e, residual = %14.7e, tol = %14.7e", iter, rho, residual, tolerance);
 
     /* 4-1 basic stopping criterion */
-    admm_has_converged = residual < tolerance;
+    admm_has_converged = 1;
 
     /* 4-2 Relative stopping criterion */
     /* admm_has_converged = (r < tolerance * fmax(r1,r2)) && (s < tolerance * s1 ) ; */
@@ -952,9 +952,9 @@ static void fc3d_admm_asymmetric(FrictionContactProblem* restrict problem,
   dparam[SICONOS_DPARAM_RESIDU] = error;
   iparam[SICONOS_IPARAM_ITER_DONE] = iter;
 
-  NM_free(A);
-  NM_free(M_s);
-  NM_free(W);
+  NM_clear(A);
+  NM_clear(M_s);
+  NM_clear(W);
 
 }
 

--- a/numerics/src/FrictionContact/fc3d_lcp_gams.c
+++ b/numerics/src/FrictionContact/fc3d_lcp_gams.c
@@ -924,7 +924,7 @@ static int fc3d_lcp_gams_base(FrictionContactProblem* problem, double *reaction,
     NumericsMatrix* NM_AbT = NM_create(NM_SPARSE, AbT->m,  AbT->n);
     numericsSparseMatrix(NM_AbT)->csc = AbT;
     SN_logh5_NM(NM_AbT, "AbT", logger_s);
-    NM_free(NM_AbT);
+    NM_clear(NM_AbT);
 #else
     cs_spfree(AbT);
 #endif
@@ -1318,10 +1318,10 @@ TERMINATE:
 
   optFree(&Optr);
   optFree(&solverOptPtr);
-  NM_free(&Wtmat);
-  NM_free(&Emat);
-  NM_free(&Akmat);
-  NM_free(tmpWmat);
+  NM_clear(&Wtmat);
+  NM_clear(&Emat);
+  NM_clear(&Akmat);
+  NM_clear(tmpWmat);
 
   free(reaction_old);
   free(velocity_old);

--- a/numerics/src/FrictionContact/fc3d_nonsmooth_Newton_solvers.c
+++ b/numerics/src/FrictionContact/fc3d_nonsmooth_Newton_solvers.c
@@ -179,8 +179,8 @@ static void computeSparseAWpB(
   /*  AWpB += AW */
   NM_gemm(1., Amat, W, 1., AWpB);
 
-  NM_free(Amat);
-  NM_free(Bmat);
+  NM_clear(Amat);
+  NM_clear(Bmat);
   free(Amat);
   free(Bmat);
 }
@@ -843,7 +843,7 @@ void fc3d_nonsmooth_Newton_solvers_solve(fc3d_nonsmooth_Newton_solvers* equation
 
   if (!options->dWork)
   {
-    NM_free(AWpB);
+    NM_clear(AWpB);
 
     free(AWpB);
   }

--- a/numerics/src/FrictionContact/gfc3d_ACLMFixedPoint.c
+++ b/numerics/src/FrictionContact/gfc3d_ACLMFixedPoint.c
@@ -160,7 +160,7 @@ void gfc3d_ACLMFixedPoint(GlobalFrictionContactProblem* restrict problem, double
   numerics_printf_verbose(1,"---- GFC3D - ACLMFP - # Iteration %i Final Residual = %14.7e", iter, error);
   numerics_printf_verbose(1,"---- GFC3D - ACLMFP - #              internal iteration = %i", cumul_iter);
 
-  NM_free(cqp->A);
+  NM_clear(cqp->A);
   free(cqp->b);
   free(cqp->q);
   free(w);

--- a/numerics/src/FrictionContact/gfc3d_AVI_gams.c
+++ b/numerics/src/FrictionContact/gfc3d_AVI_gams.c
@@ -222,9 +222,9 @@ static int gfc3d_AVI_gams_base(GlobalFrictionContactProblem* problem, double *re
 
   SN_free_SN_GAMS_gdx(gdx_data);
   free(gdx_data);
-  NM_free(&Htmat);
-  NM_free(&Emat);
-  NM_free(&Akmat);
+  NM_clear(&Htmat);
+  NM_clear(&Emat);
+  NM_clear(&Akmat);
   optFree(&Optr);
   optFree(&solverOptPtr);
   return status;

--- a/numerics/src/FrictionContact/gfc3d_LmgcDriver.c
+++ b/numerics/src/FrictionContact/gfc3d_LmgcDriver.c
@@ -276,8 +276,8 @@ int gfc3d_LmgcDriver(double *reaction,
   }
 
 
-  NM_free(M);
-  NM_free(H);
+  NM_clear(M);
+  NM_clear(H);
   free(M);
   free(H);
   free(problem);
@@ -454,8 +454,8 @@ int gfc3d_LmgcDriver(double *reaction,
 /*   } */
 
 
-/*   NM_free(&M); */
-/*   NM_free(&H); */
+/*   NM_clear(&M); */
+/*   NM_clear(&H); */
 
 /*   free(_colM); */
 /*   free(_colH); */

--- a/numerics/src/FrictionContact/gfc3d_admm.c
+++ b/numerics/src/FrictionContact/gfc3d_admm.c
@@ -312,6 +312,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
     q = rescaled_problem->q;
     b = rescaled_problem->b;
     NM_clear(Htrans);
+    free(Htrans);
     Htrans =  NM_transpose(H);
     DEBUG_EXPR
       (double norm_q = cblas_dnrm2(n , problem->q , 1);

--- a/numerics/src/FrictionContact/gfc3d_admm.c
+++ b/numerics/src/FrictionContact/gfc3d_admm.c
@@ -97,6 +97,7 @@ void gfc3d_ADMM_free(GlobalFrictionContactProblem* problem, SolverOptions* optio
     free(data->reaction_hat);
     free(data->u_hat);
     free(data->reaction_k);
+    free(data->u);
     free(data->u_k);
     free(data->b_full);
     if  (options->iparam[SICONOS_FRICTION_3D_ADMM_IPARAM_FULL_H] ==
@@ -226,6 +227,7 @@ static inline void gfc3d_ADMM_compute_full_H(int nc, double * u,
   //DEBUG_EXPR(NM_display(H));
   NM_gemm(1.0, H, H_correction, 0.0, H_full);
   NM_free(H_correction);
+  free(H_correction);
 
   DEBUG_EXPR(NM_display(H_full));
   DEBUG_END("gfc3d_ADMM_compute_H_correction(...)\n");
@@ -326,10 +328,13 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   double tolerance = dparam[0];
 
   /* Check for trivial case */
-  *info = gfc3d_checkTrivialCaseGlobal(n, q, velocity, reaction, globalVelocity, options);
-
-  if (*info == 0)
+  if(!gfc3d_checkTrivialCaseGlobal(n, q, velocity, reaction, globalVelocity, options))
+  {
+    NM_free(Htrans);
+    free(Htrans);
+    free(W);
     return;
+  }
 
   double norm_q = cblas_dnrm2(n , q , 1);
 
@@ -361,7 +366,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
     {
       numerics_printf_verbose(1,"---- GFC3D - ADMM -  M is not symmetric");
     }
-    
+
     NM_free(W);
   }
 
@@ -545,6 +550,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
         }
         else
         {
+          NM_free(W);
           NM_copy(M, W);
           NM_gemm(rho, H, Htrans, 1.0, W);
         }
@@ -884,6 +890,11 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   /***** Free memory *****/
   NM_free(W);
   NM_free(Htrans);
+  NM_free(H_full);
+  free(W);
+  free(Htrans);
+  free(H_full);
+
   if (internal_allocation)
   {
     gfc3d_ADMM_free(problem,options);

--- a/numerics/src/FrictionContact/gfc3d_admm.c
+++ b/numerics/src/FrictionContact/gfc3d_admm.c
@@ -226,7 +226,7 @@ static inline void gfc3d_ADMM_compute_full_H(int nc, double * u,
 
   //DEBUG_EXPR(NM_display(H));
   NM_gemm(1.0, H, H_correction, 0.0, H_full);
-  NM_free(H_correction);
+  NM_clear(H_correction);
   free(H_correction);
 
   DEBUG_EXPR(NM_display(H_full));
@@ -311,7 +311,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
     H = rescaled_problem->H;
     q = rescaled_problem->q;
     b = rescaled_problem->b;
-    NM_free(Htrans);
+    NM_clear(Htrans);
     Htrans =  NM_transpose(H);
     DEBUG_EXPR
       (double norm_q = cblas_dnrm2(n , problem->q , 1);
@@ -319,7 +319,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
        norm_q = cblas_dnrm2(n , rescaled_problem->q , 1);
        printf("norm_q (rescaled) = %e\n", norm_q););
   }
-  NM_free(W);
+  NM_clear(W);
 
 
   /* Maximum number of iterations */
@@ -330,7 +330,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   /* Check for trivial case */
   if(!gfc3d_checkTrivialCaseGlobal(n, q, velocity, reaction, globalVelocity, options))
   {
-    NM_free(Htrans);
+    NM_clear(Htrans);
     free(Htrans);
     free(W);
     return;
@@ -367,7 +367,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
       numerics_printf_verbose(1,"---- GFC3D - ADMM -  M is not symmetric");
     }
 
-    NM_free(W);
+    NM_clear(W);
   }
 
   int internal_allocation=0;
@@ -550,7 +550,7 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
         }
         else
         {
-          NM_free(W);
+          NM_clear(W);
           NM_copy(M, W);
           NM_gemm(rho, H, Htrans, 1.0, W);
         }
@@ -888,9 +888,9 @@ void gfc3d_ADMM(GlobalFrictionContactProblem* restrict problem, double* restrict
   iparam[SICONOS_IPARAM_ITER_DONE] = iter;
 
   /***** Free memory *****/
-  NM_free(W);
-  NM_free(Htrans);
-  NM_free(H_full);
+  NM_clear(W);
+  NM_clear(Htrans);
+  NM_clear(H_full);
   free(W);
   free(Htrans);
   free(H_full);

--- a/numerics/src/FrictionContact/gfc3d_nonsmooth_Newton_AlartCurnier.c
+++ b/numerics/src/FrictionContact/gfc3d_nonsmooth_Newton_AlartCurnier.c
@@ -831,7 +831,7 @@ void gfc3d_nonsmooth_Newton_AlartCurnier(
   }
 #endif
 
-  NM_free(AA);
+  NM_clear(AA);
   free(AA);
 }
 

--- a/numerics/src/FrictionContact/gfc3d_solvers_wr.c
+++ b/numerics/src/FrictionContact/gfc3d_solvers_wr.c
@@ -286,8 +286,8 @@ int gfc3d_reformulation_local_problem(GlobalFrictionContactProblem* problem, Fri
 
     localproblem->mu = problem->mu;
 
-    NM_free(MinvH);
-    NM_free(Htrans);
+    NM_clear(MinvH);
+    NM_clear(Htrans);
     free(MinvH);
     free(Htrans);
     free(qtmp);
@@ -487,7 +487,7 @@ int freeLocalProblem(FrictionContactProblem* localproblem)
   /*  { */
   if (localproblem->M->matrix1)
   {
-    SBM_free(localproblem->M->matrix1);
+    SBM_clear(localproblem->M->matrix1);
     free(localproblem->M->matrix1);
   }
   /*  } */

--- a/numerics/src/FrictionContact/test-utils/globalFrictionContact_test_function.c
+++ b/numerics/src/FrictionContact/test-utils/globalFrictionContact_test_function.c
@@ -195,6 +195,7 @@ int gfc3d_test_function_hdf5(const char* path, SolverOptions* options)
       }
       printf("path_copy = %s \n", path_copy);
     }
+    free(path_copy);
 
     char * path_out = (char *)calloc((nLen+10), sizeof(char));
     sprintf(path_out, "%s.dat", path); /* finally we keep the extension .hdf5.dat */
@@ -202,6 +203,7 @@ int gfc3d_test_function_hdf5(const char* path, SolverOptions* options)
     FILE * foutput  =  fopen(path_out, "w");
     info = globalFrictionContact_printInFile(problem, foutput);
     fclose(foutput);
+    free(path_out);
   }
 
 

--- a/numerics/src/FrictionContact/test/fc3d_sparse_test.c
+++ b/numerics/src/FrictionContact/test/fc3d_sparse_test.c
@@ -86,7 +86,7 @@ static int solve_sparse(int solver_id, FrictionContactProblem* FC, double* r, do
 
     NumericsMatrix* W = NM_create(NM_SPARSE, n, n);
     NM_copy_to_sparse(problem->M, W);
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = W;
 
@@ -253,9 +253,9 @@ int main(void)
 
   }
 
-  NM_free(W);
+  NM_clear(W);
   tmpM->matrix0 = NULL;
-  NM_free(tmpM);
+  NM_clear(tmpM);
   free(W);
   free(tmpM);
 

--- a/numerics/src/FrictionContact/test/gfc3d_test_collection.c.in
+++ b/numerics/src/FrictionContact/test/gfc3d_test_collection.c.in
@@ -315,6 +315,11 @@ static int gfc_test(char ** test)
 
     }
 
+    free(failed_tests);
+    free(succeeded_tests);
+    free(_data_collection);
+    free(_test_collection);
+
 #ifdef SICONOS_HAS_MPI
     MPI_Finalize();
 #endif

--- a/numerics/src/GenericMechanical/GMPReduced.c
+++ b/numerics/src/GenericMechanical/GMPReduced.c
@@ -738,7 +738,7 @@ void gmp_as_mlcp(GenericMechanicalProblem* pInProblem, double *reaction , double
     NM_fill(&M, NM_DENSE, Me_size, Me_size, reducedProb);
     *info = NM_gesv(&M, reaction, true);
     M.matrix0 = NULL;
-    NM_free(&M);
+    NM_clear(&M);
     goto END_GMP3;
   }
   /*it is a MLCP*/

--- a/numerics/src/GenericMechanical/GenericMechanical_driver.c
+++ b/numerics/src/GenericMechanical/GenericMechanical_driver.c
@@ -331,7 +331,7 @@ void gmp_gauss_seidel(GenericMechanicalProblem* pGMP, double * reaction, double 
         resLocalSolver = NM_gesv(&M, sol, true);
 
         M.matrix0 = NULL;
-        NM_free(&M);
+        NM_clear(&M);
         break;
       }
       case SICONOS_NUMERICS_PROBLEM_LCP:

--- a/numerics/src/LCP/LinearComplementarityProblem.c
+++ b/numerics/src/LCP/LinearComplementarityProblem.c
@@ -100,7 +100,7 @@ void freeLinearComplementarityProblem(LinearComplementarityProblem* problem)
 {
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = NULL;
   }

--- a/numerics/src/MCP/MixedComplementarityProblem.c
+++ b/numerics/src/MCP/MixedComplementarityProblem.c
@@ -37,7 +37,7 @@ void mixedComplementarityProblem_free(MixedComplementarityProblem* mcp)
 {
   if (mcp->nabla_Fmcp)
   {
-    NM_free(mcp->nabla_Fmcp);
+    NM_clear(mcp->nabla_Fmcp);
     free(mcp->nabla_Fmcp);
     mcp->nabla_Fmcp = NULL;
   }

--- a/numerics/src/MLCP/MixedLinearComplementarityProblem.c
+++ b/numerics/src/MLCP/MixedLinearComplementarityProblem.c
@@ -493,7 +493,7 @@ void freeMixedLinearComplementarityProblem(MixedLinearComplementarityProblem* pr
 {
   if (problem->isStorageType1)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     free(problem->q);
     free(problem->blocksRows);

--- a/numerics/src/NCP/NCP_PathSearch.c
+++ b/numerics/src/NCP/NCP_PathSearch.c
@@ -383,7 +383,7 @@ void ncp_pathsearch(NonlinearComplementarityProblem* problem, double* z, double*
 
   if (!preAlloc)
   {
-    NM_free(problem->nabla_F);
+    NM_clear(problem->nabla_F);
     free(problem->nabla_F);
     problem->nabla_F = NULL;
     free(options->dWork);

--- a/numerics/src/NCP/NonlinearComplementarityProblem.c
+++ b/numerics/src/NCP/NonlinearComplementarityProblem.c
@@ -24,7 +24,7 @@ void freeNCP(NonlinearComplementarityProblem* ncp)
 {
   if (ncp->nabla_F)
   {
-    NM_free(ncp->nabla_F);
+    NM_clear(ncp->nabla_F);
     free(ncp->nabla_F);
     ncp->nabla_F = NULL;
   }

--- a/numerics/src/NonSmoothNewton.c
+++ b/numerics/src/NonSmoothNewton.c
@@ -219,7 +219,7 @@ int nonSmoothNewton(
 
   /** Free memory*/
   free(phiVector);
-  NM_free(H);
+  NM_clear(H);
   free(gradient_psi);
   free(ipiv);
 

--- a/numerics/src/QP/ConvexQP.c
+++ b/numerics/src/QP/ConvexQP.c
@@ -81,7 +81,7 @@ void convexQP_free(ConvexQP* cqp)
 {
   if (cqp->M)
   {
-    NM_free(cqp->M);
+    NM_clear(cqp->M);
     free(cqp->M);
     cqp->M = NULL;
   }
@@ -92,7 +92,7 @@ void convexQP_free(ConvexQP* cqp)
   }
   if (cqp->A)
   {
-    NM_free(cqp->A);
+    NM_clear(cqp->A);
     free(cqp->A);
     cqp->A = NULL;
   }

--- a/numerics/src/QP/ConvexQP_ADMM.c
+++ b/numerics/src/QP/ConvexQP_ADMM.c
@@ -554,15 +554,15 @@ void convexQP_ADMM(ConvexQP* problem,
     convexQP_ADMM_free(problem,options);
   }
 
-  NM_free(W);
+  NM_clear(W);
   if (AisIdentity)
   {
-    NM_free(A);
+    NM_clear(A);
     free(b);
   }
   else
   {
-    NM_free(Atrans);
+    NM_clear(Atrans);
   }
 
 

--- a/numerics/src/Relay/RelayProblem.c
+++ b/numerics/src/Relay/RelayProblem.c
@@ -132,7 +132,7 @@ void freeRelay_problem(RelayProblem* problem)
   assert(problem);
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
   }
   if (problem->q)  { free(problem->q); }

--- a/numerics/src/Relay/relay_avi_caoferris.c
+++ b/numerics/src/Relay/relay_avi_caoferris.c
@@ -100,7 +100,7 @@ void relay_avi_caoferris(RelayProblem* problem, double *z, double *w, int *info,
   free(s_vec);
   free(A);
   free(d_vec);
-  NM_free(lcplike_pb.M);
+  NM_clear(lcplike_pb.M);
   free(lcplike_pb.q);
   free(b_bar);
 }

--- a/numerics/src/SOCP/SecondOrderConeLinearComplementarityProblem.c
+++ b/numerics/src/SOCP/SecondOrderConeLinearComplementarityProblem.c
@@ -178,7 +178,7 @@ void freeSecondOrderConeLinearComplementarityProblem(SecondOrderConeLinearComple
 
   if (problem->M)
   {
-    NM_free(problem->M);
+    NM_clear(problem->M);
     free(problem->M);
     problem->M = NULL;
   }

--- a/numerics/src/VI/VariationalInequality.c
+++ b/numerics/src/VI/VariationalInequality.c
@@ -49,7 +49,7 @@ void freeVariationalInequalityProblem(VariationalInequality* vi)
 {
   if (vi->nabla_F)
   {
-    NM_free(vi->nabla_F);
+    NM_clear(vi->nabla_F);
     free(vi->nabla_F);
     vi->nabla_F = NULL;
   }

--- a/numerics/src/VI/VariationalInequality_box_AVI.c
+++ b/numerics/src/VI/VariationalInequality_box_AVI.c
@@ -108,7 +108,7 @@ void vi_box_AVI_free_solverData(SolverOptions* options)
   assert(options->solverData);
 
   vi_box_AVI_LSA_data* sData = (vi_box_AVI_LSA_data*)options->solverData;
-  NM_free(sData->mat);
+  NM_clear(sData->mat);
   free(sData->mat);
   sData->mat = NULL;
   sData->relay_pb->lb = NULL;

--- a/numerics/src/tools/NMS.c
+++ b/numerics/src/tools/NMS.c
@@ -384,7 +384,7 @@ void free_NMS_data(NMS_data* data)
   free(data->checkpoint);
   free(data->bestpoint);
   free(data->workspace);
-  NM_free(data->H);
+  NM_clear(data->H);
   free(data->H);
   free_siconos_set(data->set);
   free(data->set);

--- a/numerics/src/tools/Newton_methods.c
+++ b/numerics/src/tools/Newton_methods.c
@@ -608,7 +608,7 @@ void newton_LSA_free_solverOptions(SolverOptions* options)
   {
     newton_LSA_data* sd = (newton_LSA_data*) options->solverData;
     assert(sd->H);
-    NM_free(sd->H);
+    NM_clear(sd->H);
     free(sd->H);
     free(sd);
     options->solverData = NULL;

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -3409,41 +3409,13 @@ double NM_norm_1(NumericsMatrix* A)
 double NM_norm_inf(NumericsMatrix* A)
 {
   assert(A);
-
-
-  switch (A->storageType)
-  {
-  case NM_DENSE:
-  {
-    assert(A->storageType == NM_DENSE);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  case NM_SPARSE_BLOCK:
-  {
-    assert(A->storageType == NM_SPARSE_BLOCK);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  case NM_SPARSE:
-  {
-    assert(A->storageType == NM_SPARSE);
-    double norm = cs_norm(cs_transpose(NM_csc(A), 1));
-    assert(norm >=0);
-    return norm;
-
-  }
-  default:
-    {
-      assert(0 && "NM_norm unknown storageType");
-    }
-  }
-  return NAN;
+  CSparseMatrix* Acsct = cs_transpose(NM_csc(A), 1);
+  double norm = cs_norm(Acsct);
+  assert(norm >=0);
+  cs_spfree(Acsct);
+  return norm;
 }
+
 int NM_is_symmetric(NumericsMatrix* A)
 {
 
@@ -3453,7 +3425,7 @@ int NM_is_symmetric(NumericsMatrix* A)
   double norm_inf = NM_norm_inf(AplusATrans);
   NM_free(Atrans); free(Atrans);
   NM_free(AplusATrans);  free(AplusATrans);
-  
+
   if (norm_inf <= DBL_EPSILON*10)
   {
     return 1;

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -495,9 +495,9 @@ void NM_internalData_copy(const NumericsMatrix* const A, NumericsMatrix* B )
     }
 
   }
-void NM_free(NumericsMatrix* m)
+void NM_clear(NumericsMatrix* m)
 {
-  assert(m && "NM_free, m == NULL");
+  assert(m && "NM_clear, m == NULL");
 
   NM_clearDense(m);
   NM_clearSparseBlock(m);
@@ -1064,7 +1064,7 @@ void NM_read_in_file(NumericsMatrix* const m, FILE *file)
   {
     NumericsMatrix * tmp = NM_new_from_file(file);
     NM_copy(tmp,m);
-    NM_free(tmp);
+    NM_clear(tmp);
   }
   else
   {
@@ -1692,7 +1692,7 @@ void NM_clearSparseBlock(NumericsMatrix* A)
 {
   if (A->matrix1)
   {
-    SBM_free(A->matrix1);
+    SBM_clear(A->matrix1);
     free(A->matrix1);
     A->matrix1 = NULL;
   }
@@ -1702,7 +1702,7 @@ void NM_clearSparse(NumericsMatrix* A)
 {
   if (A->matrix2)
   {
-    NSM_free(A->matrix2);
+    NSM_clear(A->matrix2);
     free(A->matrix2);
     A->matrix2 = NULL;
   }
@@ -2367,7 +2367,7 @@ NumericsMatrix * NM_multiply(NumericsMatrix* A, NumericsMatrix* B)
       assert(result);
       int size0 = C->size0;
       int size1 = C->size1;
-      NM_free(C);
+      NM_clear(C);
       NM_null(C);
       NM_fill(C, NM_SPARSE, size0, size1, result);
       NM_MKL_to_sparse_matrix(C);
@@ -2472,7 +2472,7 @@ void NM_gemm(const double alpha, NumericsMatrix* A, NumericsMatrix* B,
       NumericsSparseMatrix* result = NM_MKL_spblas_add(0, alpha, tmp_matrix, C->matrix2);
       int size0 = C->size0;
       int size1 = C->size1;
-      NM_free(C);
+      NM_clear(C);
       NM_null(C);
       NM_fill(C, NM_SPARSE, size0, size1, result);
       NM_MKL_to_sparse_matrix(C);
@@ -2675,7 +2675,7 @@ int NM_gesv_expert(NumericsMatrix* A, double *b, unsigned keep)
           assert(!NSM_linear_solver_data(p));
           assert(!p->solver_free_hook);
 
-          p->solver_free_hook = &NSM_free_p;
+          p->solver_free_hook = &NSM_clear_p;
           p->dWork = (double*) malloc(A->size1 * sizeof(double));
           p->dWorkSize = A->size1;
           CSparseMatrix_factors* cs_lu_A = (CSparseMatrix_factors*) malloc(sizeof(CSparseMatrix_factors));
@@ -3028,7 +3028,7 @@ int NM_posv_expert(NumericsMatrix* A, double *b, unsigned keep)
           assert(!NSM_linear_solver_data(p));
           assert(!p->solver_free_hook);
 
-          p->solver_free_hook = &NSM_free_p;
+          p->solver_free_hook = &NSM_clear_p;
           p->dWork = (double*) malloc(A->size1 * sizeof(double));
           p->dWorkSize = A->size1;
 
@@ -3215,7 +3215,7 @@ NumericsMatrix* NM_inv(NumericsMatrix* A)
     assert (0 && "NM_inv :  unknown storageType");
   }
 
-  NM_free(Atmp);
+  NM_clear(Atmp);
   free(Atmp);
   free(b);
   DEBUG_END("NM_inv(NumericsMatrix* A, double *b, unsigned keep)\n");
@@ -3423,8 +3423,8 @@ int NM_is_symmetric(NumericsMatrix* A)
   NumericsMatrix * Atrans = NM_transpose(A);
   NumericsMatrix * AplusATrans = NM_add(1/2.0, A, -1/2.0, Atrans);
   double norm_inf = NM_norm_inf(AplusATrans);
-  NM_free(Atrans); free(Atrans);
-  NM_free(AplusATrans);  free(AplusATrans);
+  NM_clear(Atrans); free(Atrans);
+  NM_clear(AplusATrans);  free(AplusATrans);
 
   if (norm_inf <= DBL_EPSILON*10)
   {

--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -245,7 +245,7 @@ extern "C"
       Note that this function does not free m.
       \param m the matrix to be deleted.
    */
-  void NM_free(NumericsMatrix* m);
+  void NM_clear(NumericsMatrix* m);
 
 
   /**************************************************/

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -118,7 +118,7 @@ NumericsSparseMatrix* NSM_new(void)
   return p;
 }
 
-NumericsSparseMatrix* NSM_free(NumericsSparseMatrix* A)
+NumericsSparseMatrix* NSM_clear(NumericsSparseMatrix* A)
 {
   if (A->linearSolverParams)
   {
@@ -237,7 +237,7 @@ NSM_linear_solver_params* NSM_linearSolverParams_free(NSM_linear_solver_params* 
   return NULL;
 }
 
-void NSM_free_p(void *p)
+void NSM_clear_p(void *p)
 {
   assert(p);
   NSM_linear_solver_params* ptr = (NSM_linear_solver_params*) p;

--- a/numerics/src/tools/NumericsSparseMatrix.h
+++ b/numerics/src/tools/NumericsSparseMatrix.h
@@ -112,7 +112,7 @@ extern "C"
    * \param A a NumericsSparseMatrix
    * \return NULL on success
    */
-  NumericsSparseMatrix* NSM_free(NumericsSparseMatrix* A);
+  NumericsSparseMatrix* NSM_clear(NumericsSparseMatrix* A);
 
 
 
@@ -120,7 +120,7 @@ extern "C"
    /** Free a workspace related to a LU factorization
    * \param p the structure to free
    */
-  void NSM_free_p(void *p);
+  void NSM_clear_p(void *p);
 
   /** Get the data part of sparse matrix
    * \param A the sparse matrix

--- a/numerics/src/tools/SiconosSets.c
+++ b/numerics/src/tools/SiconosSets.c
@@ -96,7 +96,7 @@ void free_polyhedron(polyhedron* poly)
   assert(poly);
   if (poly->H)
   {
-    NM_free(poly->H);
+    NM_clear(poly->H);
     free(poly->H);
     poly->H = NULL;
   }
@@ -107,7 +107,7 @@ void free_polyhedron(polyhedron* poly)
   }
   if (poly->Heq)
   {
-    NM_free(poly->Heq);
+    NM_clear(poly->Heq);
     free(poly->Heq);
     poly->Heq = NULL;
   }
@@ -123,7 +123,7 @@ void free_polyhedron_unified(polyhedron_unified* poly)
   assert(poly);
   if (poly->A)
   {
-    NM_free(poly->A);
+    NM_clear(poly->A);
     free(poly->A);
     poly->A = NULL;
   }

--- a/numerics/src/tools/SparseBlockMatrix.c
+++ b/numerics/src/tools/SparseBlockMatrix.c
@@ -71,7 +71,7 @@ SparseBlockStructuredMatrix* SBM_new(void)
   return sbm;
 }
 
-void SBM_free(SparseBlockStructuredMatrix *sbm)
+void SBM_clear(SparseBlockStructuredMatrix *sbm)
 {
   /* Free memory for SparseBlockStructuredMatrix */
   /* Warning: nothing is done to check if memory has really been
@@ -2032,7 +2032,7 @@ void SBM_read_in_filename(SparseBlockStructuredMatrix* const m, const char *file
 {
 
 }
-void SBM_free_pred(SparseBlockStructuredMatrixPred *blmatpred)
+void SBM_clear_pred(SparseBlockStructuredMatrixPred *blmatpred)
 {
 
   for (int i = 0 ; i < blmatpred->nbbldiag ; i++)

--- a/numerics/src/tools/SparseBlockMatrix.h
+++ b/numerics/src/tools/SparseBlockMatrix.h
@@ -66,7 +66,7 @@
     index2_data[blockNumber] -> columnNumber.
 
 
-    Related functions: SBM_gemv(), SBM_row_prod(), SBM_free(),
+    Related functions: SBM_gemv(), SBM_row_prod(), SBM_clear(),
     SBM_print, SBM_diagonal_block_index()
  * If we consider the matrix M and the right-hand-side q defined as
  *
@@ -334,7 +334,7 @@ extern "C"
   /** Destructor for SparseBlockStructuredMatrix objects
       \param blmat SparseBlockStructuredMatrix the matrix to be destroyed.
    */
-  void SBM_free(SparseBlockStructuredMatrix * blmat);
+  void SBM_clear(SparseBlockStructuredMatrix * blmat);
 
   /** To free a SBM matrix (for example allocated by NM_new_from_file).
    * \param[in] A the SparseBlockStructuredMatrix that mus be de-allocated.
@@ -387,7 +387,7 @@ extern "C"
   /** Destructor for SparseBlockStructuredMatrixPred objects
    *   \param blmatpred SparseBlockStructuredMatrix, the matrix to be destroyed.
    */
-  void SBM_free_pred(SparseBlockStructuredMatrixPred *blmatpred);
+  void SBM_clear_pred(SparseBlockStructuredMatrixPred *blmatpred);
 
   /** Compute the indices of blocks of the diagonal block
       \param M the SparseBlockStructuredMatrix matrix

--- a/numerics/src/tools/test/NM_MUMPS_test.c
+++ b/numerics/src/tools/test/NM_MUMPS_test.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   if(rank > 0)
   {
     MPI_Finalize();
-    NM_free(M);
+    NM_clear(M);
     exit(0);
   }
 #endif
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 #ifdef SICONOS_HAS_MPI
   MPI_Finalize();
 #endif
-  NM_free(M);
+  NM_clear(M);
 
   if (fabs(b[0] - 2./3.) > 1e-7) return(1);
   if (fabs(b[1] - 1./3.) > 1e-7) return(1);

--- a/numerics/src/tools/test/NM_test.c
+++ b/numerics/src/tools/test/NM_test.c
@@ -113,9 +113,9 @@ static int NM_read_write_test(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
-    NM_free(Mread[i]);
+    NM_clear(Mread[i]);
     free(Mread[i]);
   }
 
@@ -189,10 +189,10 @@ static int NM_add_to_diag3_test(NumericsMatrix* M, double alpha)
   }
 
 exit_1:
-  NM_free(C2);
+  NM_clear(C2);
 exit_0:
   free(Id);
-  NM_free(Cref);
+  NM_clear(Cref);
 
   return info;
 }
@@ -223,7 +223,7 @@ static int  NM_add_to_diag3_test_all(void)
   /* free memory */
 
 
-  NM_free(M);
+  NM_clear(M);
 
   printf("========= End Numerics tests for NM_add_to_diag3 ========= \n");
   return info;
@@ -697,28 +697,28 @@ static int NM_gemm_test(NumericsMatrix** MM, double alpha, double beta)
   }
 
 exit_9:
-  NM_free(C20);
+  NM_clear(C20);
 exit_8:
-  NM_free(M10);
-  NM_free(C8);
+  NM_clear(M10);
+  NM_clear(C8);
 exit_7:
-  NM_free(M9);
-  NM_free(C7);
+  NM_clear(M9);
+  NM_clear(C7);
 exit_6:
-  NM_free(M6);
-  NM_free(C6);
+  NM_clear(M6);
+  NM_clear(C6);
 exit_5:
-  NM_free(M5);
-  NM_free(C5);
+  NM_clear(M5);
+  NM_clear(C5);
 exit_4:
-  NM_free(&C4);
+  NM_clear(&C4);
 exit_3:
-  NM_free(&C3);
+  NM_clear(&C3);
 exit_2:
   free(C2.matrix0);
-  NM_free(C2ref);
+  NM_clear(C2ref);
 exit_1:
-  NM_free(Cref);
+  NM_clear(Cref);
   free(C.matrix0);
   return info;
 }
@@ -770,7 +770,7 @@ static int NM_gemm_test_all(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
 
@@ -982,7 +982,7 @@ static int NM_gemm_test_all2(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
 
@@ -1127,11 +1127,11 @@ static int NM_row_prod_test(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     /*    if (NMM[i]->matrix0) */
     /*        free(NMM[i]->matrix0); */
     /*    if (NMM[i]->matrix1) */
-    /*        SBM_free(NMM[i]->matrix1); */
+    /*        SBM_clear(NMM[i]->matrix1); */
     free(NMM[i]);
   }
 
@@ -1266,7 +1266,7 @@ static int NM_row_prod_no_diag_test_all(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
 
@@ -1409,7 +1409,7 @@ static int NM_row_prod_no_diag_non_square_test(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
 
@@ -1551,7 +1551,7 @@ static int test_NM_row_prod_non_square_test(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);
@@ -1616,15 +1616,15 @@ static int test_NM_iterated_power_method(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);
-  NM_free(Id);
-  NM_free(Atrans);
-  NM_free(Btrans);
-  NM_free(AAT);
-  NM_free(BBT);
+  NM_clear(Id);
+  NM_clear(Atrans);
+  NM_clear(Btrans);
+  NM_clear(AAT);
+  NM_clear(BBT);
 
 
 
@@ -1685,12 +1685,12 @@ static int test_NM_scal(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);
-  NM_free(Id);
-  NM_free(B);
+  NM_clear(Id);
+  NM_clear(B);
 
 
   printf("========= End Numerics tests for NumericsMatrix NM_scal========= \n");
@@ -1746,24 +1746,24 @@ static int test_NM_inv(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);
-  NM_free(Id);
-  NM_free(Iinv);
-  NM_free(IIinv);
+  NM_clear(Id);
+  NM_clear(Iinv);
+  NM_clear(IIinv);
 
-  NM_free(AAinv);
-  NM_free(Ainv);
-  NM_free(IA);
-  NM_free(BBinv);
-  NM_free(Binv);
-  NM_free(IB);
-  NM_free(CCinv);
-  NM_free(Cinv);
-  NM_free(IC);
-  NM_free(C);
+  NM_clear(AAinv);
+  NM_clear(Ainv);
+  NM_clear(IA);
+  NM_clear(BBinv);
+  NM_clear(Binv);
+  NM_clear(IB);
+  NM_clear(CCinv);
+  NM_clear(Cinv);
+  NM_clear(IC);
+  NM_clear(C);
 
   printf("========= End Numerics tests for NumericsMatrix NM_inv ========= \n");
   return info;
@@ -1848,7 +1848,7 @@ static int test_NM_gesv_expert(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);
@@ -1969,7 +1969,7 @@ static int test_NM_posv_expert(void)
   }
   info = test_NM_posv_expert_unit(Id, b);
   if (info != 0) return info;
-  NM_free(Id);
+  NM_clear(Id);
   free(Id);
 
   NumericsMatrix * Z = NM_create(NM_SPARSE,2,2);
@@ -1981,7 +1981,7 @@ static int test_NM_posv_expert(void)
   NM_zentry(Z,1,0,1.0);
   info = test_NM_posv_expert_unit(Z, b);
   if (info != 0) return info;
-  NM_free(Z);
+  NM_clear(Z);
   free(Z);
 
   M1 = NMM[0];
@@ -1994,8 +1994,8 @@ static int test_NM_posv_expert(void)
     b[j] =1.0;
   info = test_NM_posv_expert_unit(C, b);
   if (info != 0) return info;
-  NM_free(M1T);
-  NM_free(C);
+  NM_clear(M1T);
+  NM_clear(C);
 
   /* M1=NMM[1]; */
   /* M1T = NM_transpose(M1); */
@@ -2031,7 +2031,7 @@ static int test_NM_posv_expert(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
   free(NMM);

--- a/numerics/src/tools/test/SBM_test.c
+++ b/numerics/src/tools/test/SBM_test.c
@@ -80,8 +80,8 @@ static int SBM_add_test1(double tol, double alpha, double beta)
   free(M_dense);
   free(C_dense);
 
-  SBM_free(M);
-  SBM_free(C);
+  SBM_clear(M);
+  SBM_clear(C);
   return info;
 
 }
@@ -150,10 +150,10 @@ static int SBM_add_test2(double tol, double alpha, double beta)
   if (info == 1)
     return info;
   
-  NM_free(M2);
-  NM_free(M10);
-  SBM_free(C2);
-  SBM_free(C3);
+  NM_clear(M2);
+  NM_clear(M10);
+  SBM_clear(C2);
+  SBM_clear(C3);
   free(C2_dense);
   free(C3_dense);
   free(M2_dense);
@@ -242,7 +242,7 @@ int test_SBM_column_permutation_all(void)
     printf("========= Failed SBM tests 3 for SBM  ========= \n");
     return 1;
   }
-  SBM_free(M);
+  SBM_clear(M);
   file = fopen("data/SBM2.dat", "r");
   M = SBM_new_from_file(file);
   fclose(file);
@@ -252,7 +252,7 @@ int test_SBM_column_permutation_all(void)
     printf("========= Failed SBM tests 3 for SBM  ========= \n");
     return 1;
   }
-  SBM_free(M);
+  SBM_clear(M);
   printf("\n========= Succed SBM tests 3 for SBM  ========= \n");
   return 0;
 
@@ -311,7 +311,7 @@ int SBM_extract_component_3x3_all(void)
     return 1;
   }
 
-  SBM_free(M);
+  SBM_clear(M);
   
   return 0;
 
@@ -695,22 +695,22 @@ static int SBM_gemm_without_allocation_test(NumericsMatrix** MM, double alpha, d
 
 
 exit_9:
-  NM_free(C20);
+  NM_clear(C20);
 exit_8:
-  NM_free(M10);
-  NM_free(C8);
+  NM_clear(M10);
+  NM_clear(C8);
 exit_7:
-  NM_free(M9);
-  NM_free(C7);
+  NM_clear(M9);
+  NM_clear(C7);
 exit_4:
-  NM_free(&C4);
+  NM_clear(&C4);
 exit_3:
-  NM_free(&C3);
+  NM_clear(&C3);
 exit_2:
   free(C2.matrix0);
-  NM_free(C2ref);
+  NM_clear(C2ref);
 exit_1:
-  NM_free(Cref);
+  NM_clear(Cref);
   free(C.matrix0);
   return info;
 }
@@ -762,7 +762,7 @@ int SBM_gemm_without_allocation_all(void)
 
   for (i = 0 ; i < nmm; i++)
   {
-    NM_free(NMM[i]);
+    NM_clear(NMM[i]);
     free(NMM[i]);
   }
 
@@ -809,8 +809,8 @@ static int SBM_multiply_test1(double tol)
   free(M_dense);
   free(C_dense);
 
-  SBM_free(M);
-  SBM_free(C);
+  SBM_clear(M);
+  SBM_clear(C);
   return info;
 }
 
@@ -867,10 +867,10 @@ static int SBM_multiply_test2(double tol)
   if (info == 1)
     return info;
 
-  NM_free(M2);
-  NM_free(M10);
-  SBM_free(C2);
-  SBM_free(C3);
+  NM_clear(M2);
+  NM_clear(M10);
+  SBM_clear(C2);
+  SBM_clear(C3);
   free(C2_dense);
   free(C3_dense);
   free(M2_dense);
@@ -920,9 +920,9 @@ static int SBM_multiply_test3(double tol)
   info = SBM_dense_equal(C2, C2_dense, tol);
   
 
-  NM_free(M2);
-  NM_free(M4);
-  SBM_free(C2);
+  NM_clear(M2);
+  NM_clear(M4);
+  SBM_clear(C2);
   free(C2_dense);
   free(M2_dense);
   free(M4_dense);
@@ -979,7 +979,7 @@ int test_SBM_row_permutation_all(void)
     return 1;
   }
 
-  SBM_free(M);
+  SBM_clear(M);
 
   
   file = fopen("data/SBM2.dat", "r");
@@ -991,7 +991,7 @@ int test_SBM_row_permutation_all(void)
     printf("========= Failed SBM tests 2 for SBM  ========= \n");
     return 1;
   }
-  SBM_free(M2);
+  SBM_clear(M2);
   printf("\n========= Succed SBM tests 2 for SBM  ========= \n");
   return 0;
 
@@ -1017,7 +1017,7 @@ int test_SBM_row_to_dense_all(void)
     return 1;
   }
 
-  SBM_free(M);
+  SBM_clear(M);
 
 
 
@@ -1030,7 +1030,7 @@ int test_SBM_row_to_dense_all(void)
     printf("========= Failed SBM tests 1 for SBM  ========= \n");
     return 1;
   }
-  SBM_free(M2);
+  SBM_clear(M2);
   printf("\n========= Succeeded SBM tests 1 for SBM  ========= \n");
   return 0;
 
@@ -1085,7 +1085,7 @@ int SBM_to_dense_all(void)
   printf("\n (warning: column-major) \n");
 
   free(denseMat);
-  SBM_free(M);
+  SBM_clear(M);
   printf("\n========= Succed SBM tests 4 for SBM  ========= \n");
   return 0;
 
@@ -1140,7 +1140,7 @@ int SBM_to_sparse_all(void)
 
   free(denseMat);
   printf("NUMERICS_SBM_FREE_BLOCK value %d", NUMERICS_SBM_FREE_BLOCK);
-  SBM_free(M);
+  SBM_clear(M);
   printf("\n========= Succed SBM tests 4 for SBM  ========= \n");
   return 0;
 
@@ -1234,9 +1234,9 @@ static int SBM_zentry_test1(double tol)
   DEBUG_EXPR(NM_display(C));
   DEBUG_EXPR(NM_display(C2));
   info = NM_dense_equal(C2,C->matrix0,tol);
-  NM_free(M2);
-  NM_free(C2);
-  NM_free(C);
+  NM_clear(M2);
+  NM_clear(C2);
+  NM_clear(C);
   return info;
 }
 
@@ -1255,7 +1255,7 @@ static int SBM_zentry_test2(double tol)
   info = SBM_zentry(M2->matrix1,8,0,1.0);
   info = SBM_zentry(M2->matrix1,0,7,1.0);
 
-  NM_free(M2);
+  NM_clear(M2);
 
   return info;
 }

--- a/numerics/src/tools/test/main_NumericsMatrix.c
+++ b/numerics/src/tools/test/main_NumericsMatrix.c
@@ -79,7 +79,7 @@ int main(void)
     if (NMM[i]->matrix0)
       free(NMM[i]->matrix0);
     if (NMM[i]->matrix1)
-      SBM_free(NMM[i]->matrix1);
+      SBM_clear(NMM[i]->matrix1);
     free(NMM[i]);
   }
 

--- a/numerics/src/tools/test/test_pinv.c
+++ b/numerics/src/tools/test/test_pinv.c
@@ -170,8 +170,8 @@ int main(void)
 
 
   free(Wpinvtest);
-  NM_free(Wnum);
-  NM_free(WnumpInv);
+  NM_clear(Wnum);
+  NM_clear(WnumpInv);
   free(Wnum);
   free(WnumpInv);
 

--- a/numerics/swig/Numerics_MCP2.i
+++ b/numerics/swig/Numerics_MCP2.i
@@ -73,7 +73,7 @@
        target_mem_mgmtX_instr(method_compute_F);
        target_mem_mgmtX_instr(method_compute_nabla_F);
        SWIG_Error(SWIG_TypeError, "argument 2 must be have a method compute_F and a method compute_nabla_F");
-       NM_free(MCP->nabla_Fmcp);
+       NM_clear(MCP->nabla_Fmcp);
        free(MCP->nabla_Fmcp);
        free(MCP);
        return NULL;

--- a/numerics/swig/Numerics_NCP.i
+++ b/numerics/swig/Numerics_NCP.i
@@ -81,7 +81,7 @@
        target_mem_mgmtX_instr(method_compute_F);
        target_mem_mgmtX_instr(method_compute_nabla_F);
        SWIG_Error(SWIG_TypeError, "argument 2 must be have a method compute_F and a method compute_nabla_F");
-       NM_free(NCP->nabla_F);
+       NM_clear(NCP->nabla_F);
        free(NCP->nabla_F);
        free(NCP);
        return NULL;
@@ -149,7 +149,7 @@
   {
     if ($self->nabla_F)
     {
-      NM_free($self->nabla_F);
+      NM_clear($self->nabla_F);
       free($self->nabla_F);
     }
     if ($self->env)

--- a/numerics/swig/Numerics_typemaps_numericsmatrices.i
+++ b/numerics/swig/Numerics_typemaps_numericsmatrices.i
@@ -128,7 +128,7 @@
   if (nummat$argnum)
   {
     if (!NM_clean(nummat$argnum, alloc_ctrl_$argnum)) { return SN_SWIG_ERROR_CODE; }
-    NM_free(nummat$argnum);
+    NM_clear(nummat$argnum);
     free(nummat$argnum);
   }
 

--- a/numerics/swig/numerics_NM.i
+++ b/numerics/swig/numerics_NM.i
@@ -144,7 +144,7 @@
 
   ~NumericsMatrix()
   {
-    NM_free($self);
+    NM_clear($self);
     free($self);
   }
 
@@ -154,7 +154,7 @@
 {
  ~SparseBlockStructuredMatrix()
  {
-   SBM_free($self);
+   SBM_clear($self);
    free($self);
  }
 }


### PR DESCRIPTION
This comes from some valgrind traces on gfc3d admm tests.

Many errors come from the fact that NM_free does not free the pointer! I Propose in this PR, along with a few fixes in gfc3d admm, to rename NM_free and NSM_free to NM_clear and NSM_clear.
But It seems like there is a lot of other places in numerics code where free is not done after these *_clear calls. 