### PR TITLE
[numerics] increase tolerance for NM_compare (fix #330)

### DIFF
--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -753,7 +753,7 @@ double NM_get_value(const NumericsMatrix* const M, int i, int j)
 
 bool NM_equal(NumericsMatrix* A, NumericsMatrix* B)
 {
-  return NM_compare(A, B, DBL_EPSILON);
+  return NM_compare(A, B, DBL_EPSILON*2);
 };
 
 bool NM_compare(NumericsMatrix* A, NumericsMatrix* B, double tol)


### PR DESCRIPTION
The failure in #330 occured for me in NM_compare from NM_inv_test. This is fixed by an increase to the tolerance passed from NM_equal to NM_compare.