### PR TITLE
[numerics,kernel] invalidate other storages

### DIFF
--- a/kernel/src/simulationTools/MLCP.cpp
+++ b/kernel/src/simulationTools/MLCP.cpp
@@ -161,6 +161,10 @@ int MLCP::compute(double time)
 
   /*If user has not allocted the working memory, do it. */
   mlcp_driver_init(&*_numerics_problem, &*_numerics_solver_options);
+  // After the first call the mlcp_direct_init must not reset the previous guess
+  // But as the problem may change the MLCP update flag is raised
+  _numerics_solver_options->iparam[SICONOS_IPARAM_MLCP_UPDATE_REQUIRED] = 1;
+
   // --- Call Numerics driver ---
   // Inputs:
   // - the problem (M,q ...)

--- a/kernel/src/simulationTools/OSNSMatrix.cpp
+++ b/kernel/src/simulationTools/OSNSMatrix.cpp
@@ -260,7 +260,6 @@ void OSNSMatrix::fillW(InteractionsGraph& indexSet, bool update)
       ->setBlock(std::max(pos, col), std::min(pos, col),
                  *indexSet.properties(*ei).lower_block);
     }
-
   }
   else if(_storageType == NM_SPARSE_BLOCK)
   {
@@ -276,7 +275,8 @@ void OSNSMatrix::fillW(InteractionsGraph& indexSet, bool update)
       _M2->fill(indexSet);
     }
   }
-
+  // invalidate other old storages.
+  NM_clear_other_storages(_numericsMatrix.get(), _storageType);
   if(update)
     convert();
   DEBUG_END("void OSNSMatrix::fill(SP::InteractionsGraph indexSet, bool update)\n");
@@ -363,6 +363,7 @@ void OSNSMatrix::fillM(DynamicalSystemsGraph & DSG, bool update)
         DEBUG_PRINTF("pos = %u \n", pos);
       }
     }
+    // invalidate other old storages.
     DEBUG_EXPR(NM_display(numericsMatrix().get()););
     break;
   }
@@ -370,6 +371,9 @@ void OSNSMatrix::fillM(DynamicalSystemsGraph & DSG, bool update)
   {
     RuntimeException::selfThrow("OSNSMatrix::convert unknown _storageType");
   }
+  // invalidate other old storages.
+  NM_clear_other_storages(_numericsMatrix.get(), _storageType);
+
   }
 
 
@@ -436,6 +440,8 @@ void OSNSMatrix::fillH(DynamicalSystemsGraph & DSG, InteractionsGraph& indexSet,
       }
 
     }
+    // invalidate other old storages.
+    NM_clear_other_storages(_numericsMatrix.get(), _storageType);
     break;
   }
   default:

--- a/kernel/src/simulationTools/OSNSMatrix.cpp
+++ b/kernel/src/simulationTools/OSNSMatrix.cpp
@@ -276,6 +276,9 @@ void OSNSMatrix::fillW(InteractionsGraph& indexSet, bool update)
     }
   }
   // invalidate other old storages.
+  _numericsMatrix.get()->storageType = _storageType ;
+  _numericsMatrix.get()->size0 = _dimRow ;
+  _numericsMatrix.get()->size1 = _dimColumn ;
   NM_clear_other_storages(_numericsMatrix.get(), _storageType);
   if(update)
     convert();

--- a/numerics/src/MLCP/mlcp_direct.c
+++ b/numerics/src/MLCP/mlcp_direct.c
@@ -139,9 +139,17 @@ void mlcp_direct_init(MixedLinearComplementarityProblem* problem, SolverOptions*
     printf("n= %d  m= %d /n sTolneg= %lf sTolpos= %lf \n", sN, sM, sTolneg, sTolpos);
 
   sNpM = sN + sM;
-  //spCurCC = 0;
-  //spFirstCC = 0;
-  //sNumberOfCC = 0;
+
+  // If the problem comes from the kernel (dynamical systems)
+  // Then update is needed but no reset of the previous solutions
+  // (This avoids some memory loss by the way)
+  if(options->iparam[SICONOS_IPARAM_MLCP_UPDATE_REQUIRED]==0)
+  {
+    spCurCC = 0;
+    spFirstCC = 0;
+    sNumberOfCC = 0;
+  }
+
   sQ = mydMalloc(sNpM);
   sVBuf = mydMalloc(sNpM);
   spIntBuf = myiMalloc(sNpM);

--- a/numerics/src/MLCP/mlcp_direct.c
+++ b/numerics/src/MLCP/mlcp_direct.c
@@ -139,9 +139,9 @@ void mlcp_direct_init(MixedLinearComplementarityProblem* problem, SolverOptions*
     printf("n= %d  m= %d /n sTolneg= %lf sTolpos= %lf \n", sN, sM, sTolneg, sTolpos);
 
   sNpM = sN + sM;
-  spCurCC = 0;
-  spFirstCC = 0;
-  sNumberOfCC = 0;
+  //spCurCC = 0;
+  //spFirstCC = 0;
+  //sNumberOfCC = 0;
   sQ = mydMalloc(sNpM);
   sVBuf = mydMalloc(sNpM);
   spIntBuf = myiMalloc(sNpM);

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -516,7 +516,7 @@ void NM_clear_other_storages(NumericsMatrix* M, int storageType)
 {
   assert(M && "NM_clear, M == NULL");
 
-  switch(M->storageType)
+  switch(storageType)
   {
   case NM_DENSE:
   {

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -515,6 +515,8 @@ void NM_clear(NumericsMatrix* m)
 void NM_clear_other_storages(NumericsMatrix* M, int storageType)
 {
   assert(M && "NM_clear, M == NULL");
+  assert(M->storageType >=0 && "M->storageType >=0");
+  assert(M->storageType <3 && "M->storageType < 3");
 
   switch(storageType)
   {
@@ -1738,11 +1740,12 @@ void NM_fill(NumericsMatrix* M, int storageType, int size0, int size1, void* dat
 {
 
   assert(M);
+  NM_null(M);
   M->storageType = storageType;
   M->size0 = size0;
   M->size1 = size1;
 
-  NM_null(M);
+
 
   if(data)
   {

--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -265,6 +265,13 @@ extern "C"
    */
   void NM_clear(NumericsMatrix* m);
 
+  /** Free memory for a NumericsMatrix except for a given storage. Warning: call this function only if you are sure that
+      memory has been allocated for the structure in Numerics. This function is assumed that the memory is "owned" by this structure.
+      Note that this function does not free m.
+      \param m the matrix to be deleted.
+      \param storageType to be kept.
+   */
+  void NM_clear_other_storages(NumericsMatrix* M, int storageType);
 
   /**************************************************/
   /** setters and getters               *************/

--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -223,6 +223,9 @@ extern "C"
    */
   static inline void NM_null(NumericsMatrix* A)
   {
+    A->storageType=-1;
+    A->size0 =-1;
+    A->size1 =-1;
     A->matrix0 = nullptr;
     A->matrix1 = nullptr;
     A->matrix2 = nullptr;


### PR DESCRIPTION
when we fill a NumericsMatrix from the kernel

The goal of this PR is to clear the other storages in NumericsMatrix when we fill it again form the kernel.

