### PR TITLE
[numerics] add MUMPS for sparse rhs (LU & Cholesky)

### DIFF
--- a/numerics/src/tools/NM_MUMPS.h
+++ b/numerics/src/tools/NM_MUMPS.h
@@ -100,12 +100,20 @@ extern "C"
    */
   double NM_MUMPS_cntl(NumericsMatrix* A, unsigned int index);
 
-  /** Set linear problem
+  /** Set linear problem.
    * \param A, the matrix holding the MUMPS config,
    * \param nrhs, the number of right hand side.
    * \param b, a pointer on double values of the right hand side.
    */
   void NM_MUMPS_set_problem(NumericsMatrix* A, unsigned int nrhs, double *b);
+
+  /** Set linear problem with sparse right hand side.
+   * \param A, the matrix holding the MUMPS config,
+   * \param B, the matrix holding the right hand side.
+   * B is converted to csc if not already stored in this
+   * representation. The solution is returned in B in the DENSE format.
+   */
+  void NM_MUMPS_set_sparse_rhs_problem(NumericsMatrix* A, NumericsMatrix* B);
 
   /** Set MUMPS verbosity.
    * \param A, the matrix holding the MUMPS config,

--- a/numerics/src/tools/NM_MUMPS.h
+++ b/numerics/src/tools/NM_MUMPS.h
@@ -100,20 +100,27 @@ extern "C"
    */
   double NM_MUMPS_cntl(NumericsMatrix* A, unsigned int index);
 
-  /** Set linear problem.
+  /** Set matrix before factorization.
    * \param A, the matrix holding the MUMPS config,
    * \param nrhs, the number of right hand side.
    * \param b, a pointer on double values of the right hand side.
    */
-  void NM_MUMPS_set_problem(NumericsMatrix* A, unsigned int nrhs, double *b);
+  void NM_MUMPS_set_matrix(NumericsMatrix* A);
 
-  /** Set linear problem with sparse right hand side.
+  /** Set dense right hand side.
+   * \param A, the matrix holding the MUMPS config,
+   * \param nrhs, the number of right hand side.
+   * \param b, a pointer on double values of the right hand side.
+   */
+  void NM_MUMPS_set_dense_rhs(NumericsMatrix* A, unsigned int nrhs, double *b);
+
+  /** Set sparse right hand side.
    * \param A, the matrix holding the MUMPS config,
    * \param B, the matrix holding the right hand side.
    * B is converted to csc if not already stored in this
-   * representation. The solution is returned in B in the DENSE format.
+   * representation.
    */
-  void NM_MUMPS_set_sparse_rhs_problem(NumericsMatrix* A, NumericsMatrix* B);
+  void NM_MUMPS_set_sparse_rhs(NumericsMatrix* A, NumericsMatrix* B);
 
   /** Set MUMPS verbosity.
    * \param A, the matrix holding the MUMPS config,

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -3256,7 +3256,7 @@ int NM_LU_factorize(NumericsMatrix* Ao)
           NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value
         }
 
-        NM_MUMPS_set_problem(A, 0, NULL);
+        NM_MUMPS_set_matrix(A);
 
         NM_MUMPS(A, 4); /* analyzis,factorization */
 
@@ -3392,7 +3392,7 @@ int NM_LU_solve(NumericsMatrix* Ao, double *b, unsigned int nrhs)
 
         DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-        NM_MUMPS_set_problem(A, nrhs, b);
+        NM_MUMPS_set_dense_rhs(A, nrhs, b);
 
         NM_MUMPS(A, 3); /* solve */
         info = mumps_id->info[0];
@@ -3500,7 +3500,6 @@ int NM_LU_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
 #ifdef WITH_MUMPS
         case NSM_MUMPS:
         {
-
           numerics_printf_verbose(2,"NM_LU_solve: using MUMPS\n");
 
           assert (NM_MUMPS_id(A)->job); /* this means that at least a
@@ -3509,7 +3508,7 @@ int NM_LU_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
 
           DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-          NM_MUMPS_set_sparse_rhs_problem(A, B);
+          NM_MUMPS_set_sparse_rhs(A, B);
 
           NM_MUMPS(A, 3); /* solve */
           info = mumps_id->info[0];
@@ -3707,7 +3706,8 @@ int NM_gesv_expert(NumericsMatrix* A, double *b, unsigned keep)
         NM_MUMPS_set_icntl(A, 24, 1); // Null pivot row detection
         NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value
       }
-      NM_MUMPS_set_problem(A, 1, b);
+      NM_MUMPS_set_matrix(A);
+      NM_MUMPS_set_dense_rhs(A, 1, b);
 
       DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
@@ -4094,7 +4094,8 @@ int NM_posv_expert(NumericsMatrix* A, double *b, unsigned keep)
         NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value
       }
 
-      NM_MUMPS_set_problem(A, 1, b);
+      NM_MUMPS_set_matrix(A);
+      NM_MUMPS_set_dense_rhs(A, 1, b);
 
       DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
@@ -4958,7 +4959,7 @@ int NM_Cholesky_factorize(NumericsMatrix* Ao)
           /* NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value */
         }
 
-        NM_MUMPS_set_problem(A, 0, NULL);
+        NM_MUMPS_set_matrix(A);
 
         NM_MUMPS(A, 4); /* analyzis,factorization */
 
@@ -5084,7 +5085,7 @@ int NM_Cholesky_solve(NumericsMatrix* Ao, double *b, unsigned int nrhs)
 
         DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-        NM_MUMPS_set_problem(A, nrhs, b);
+        NM_MUMPS_set_dense_rhs(A, nrhs, b);
 
         NM_MUMPS(A, 3); /* solve */
         info = mumps_id->info[0];
@@ -5194,7 +5195,6 @@ int NM_Cholesky_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
         case NSM_MUMPS:
         {
           numerics_printf_verbose(2,"NM_Cholesky_solve: using MUMPS\n");
-          //numerics_error("NM_Cholesky_solve_matrix_rhs"," not yet implemented\n")
 
           assert (NM_MUMPS_id(A)->job); /* this means that at least a
                                          * factorization has already been
@@ -5202,7 +5202,7 @@ int NM_Cholesky_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
 
           DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-          NM_MUMPS_set_sparse_rhs_problem(A, B);
+          NM_MUMPS_set_sparse_rhs(A, B);
 
           NM_MUMPS(A, 3); /* solve */
           info = mumps_id->info[0];
@@ -5396,7 +5396,7 @@ int NM_LDLT_factorize(NumericsMatrix* Ao)
           /* NM_MUMPS_set_cntl(A, 5, 1.e20); // Fixation, recommended value */
         }
 
-        NM_MUMPS_set_problem(A, 0, NULL);
+        NM_MUMPS_set_matrix(A);
 
         NM_MUMPS(A, 4); /* analyzis,factorization */
 
@@ -5535,7 +5535,7 @@ int NM_LDLT_solve(NumericsMatrix* Ao, double *b, unsigned int nrhs)
 
         DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-        NM_MUMPS_set_problem(A, nrhs, b);
+        NM_MUMPS_set_dense_rhs(A, nrhs, b);
 
         NM_MUMPS(A, 3); /* solve */
         info = mumps_id->info[0];

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -3500,16 +3500,16 @@ int NM_LU_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
 #ifdef WITH_MUMPS
         case NSM_MUMPS:
         {
-          numerics_printf_verbose(2,"NM_LU_solve: using MUMPS\n");
-          numerics_error("NM_LU_solve_matrix_rhs"," not yet implemented\n")
 
-          assert (NM_MUMPS_id(A)->job); /* this means that least a
+          numerics_printf_verbose(2,"NM_LU_solve: using MUMPS\n");
+
+          assert (NM_MUMPS_id(A)->job); /* this means that at least a
                                          * factorization has already been
                                          * done */
 
           DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-          NM_MUMPS_set_problem(A, nrhs, b);
+          NM_MUMPS_set_sparse_rhs_problem(A, B);
 
           NM_MUMPS(A, 3); /* solve */
           info = mumps_id->info[0];
@@ -3522,6 +3522,16 @@ int NM_LU_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
               fprintf(stderr,"NM_LU_solve: MUMPS fails : info(1)=%d, info(2)=%d\n", info, mumps_id->info[1]);
             }
           }
+
+          /* solution is returned in the DENSE format in the B matrix */
+          NM_clear(B);
+          B->storageType = NM_DENSE;
+          B->size0 = A->size0;
+          B->size1 = mumps_id->nrhs;
+          B->matrix0 = (double *) malloc(
+            A->size0*mumps_id->nrhs*sizeof(double));
+          memcpy(B->matrix0, mumps_id->rhs,
+                 A->size0*mumps_id->nrhs*sizeof(double));
           break;
         }
 #endif /* WITH_MUMPS */
@@ -5184,15 +5194,15 @@ int NM_Cholesky_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
         case NSM_MUMPS:
         {
           numerics_printf_verbose(2,"NM_Cholesky_solve: using MUMPS\n");
-          numerics_error("NM_Cholesky_solve_matrix_rhs"," not yet implemented\n")
+          //numerics_error("NM_Cholesky_solve_matrix_rhs"," not yet implemented\n")
 
-          assert (NM_MUMPS_id(A)->job); /* this means that least a
+          assert (NM_MUMPS_id(A)->job); /* this means that at least a
                                          * factorization has already been
                                          * done */
 
           DMUMPS_STRUC_C* mumps_id = NM_MUMPS_id(A);
 
-          NM_MUMPS_set_problem(A, nrhs, b);
+          NM_MUMPS_set_sparse_rhs_problem(A, B);
 
           NM_MUMPS(A, 3); /* solve */
           info = mumps_id->info[0];
@@ -5205,6 +5215,16 @@ int NM_Cholesky_solve_matrix_rhs(NumericsMatrix* Ao, NumericsMatrix* B)
               fprintf(stderr,"NM_Cholesky_solve: MUMPS fails : info(1)=%d, info(2)=%d\n", info, mumps_id->info[1]);
             }
           }
+
+          /* solution is returned in the DENSE format in the B matrix */
+          NM_clear(B);
+          B->storageType = NM_DENSE;
+          B->size0 = A->size0;
+          B->size1 = mumps_id->nrhs;
+          B->matrix0 = (double *) malloc(
+            A->size0*mumps_id->nrhs*sizeof(double));
+          memcpy(B->matrix0, mumps_id->rhs,
+                 A->size0*mumps_id->nrhs*sizeof(double));
           break;
         }
 #endif /* WITH_MUMPS */

--- a/numerics/src/tools/test/NM_MUMPS_test.c
+++ b/numerics/src/tools/test/NM_MUMPS_test.c
@@ -67,7 +67,8 @@ int main(int argc, char *argv[])
     b[2] = 1.;
     b[3] = 0.;
 
-    NM_MUMPS_set_problem(M, 2, b);
+    NM_MUMPS_set_matrix(M);
+    NM_MUMPS_set_dense_rhs(M, 2, b);
     NM_MUMPS(M, 6);
     NM_MUMPS(M, -2);
     NM_MUMPS(M, 0);
@@ -134,7 +135,8 @@ int main(int argc, char *argv[])
     b[4] = 0.;
     b[5] = 1.;
 
-    NM_MUMPS_set_problem(M, 2, b);
+    NM_MUMPS_set_matrix(M);
+    NM_MUMPS_set_dense_rhs(M, 2, b);
     NM_MUMPS(M, 6);
     NM_MUMPS(M, -2);
     NM_MUMPS(M, 0);

--- a/numerics/src/tools/test/NM_test.c
+++ b/numerics/src/tools/test/NM_test.c
@@ -2933,6 +2933,7 @@ static int test_NM_LU_solve_matrix_rhs(void)
     B->matrix0[j+j*n] = 1.0;
   info = test_NM_LU_solve_matrix_rhs_unit(M1, B);
   NM_clear(B);
+  if(info != 0) return info;
 
   /* SPARSE matrix, SPARSE RHS */
   M1 = test_matrix_5();

--- a/numerics/src/tools/test/NM_test.c
+++ b/numerics/src/tools/test/NM_test.c
@@ -2882,6 +2882,7 @@ static int test_NM_LU_solve_matrix_rhs_unit(NumericsMatrix * M1, NumericsMatrix 
 }
 static int test_NM_LU_solve_matrix_rhs(void)
 {
+  numerics_set_verbose(3);
 
   printf("========= Starts Numerics tests for NumericsMatrix (test_NM_LU_solve) ========= \n");
   /* numerics_set_verbose(2); */

--- a/numerics/swig/tests/test_NM_MUMPS.py
+++ b/numerics/swig/tests/test_NM_MUMPS.py
@@ -39,7 +39,8 @@ def test_nm_mumps():
     numerics.NM_entry(M, 1, 1, 1.)
 
     b = numpy.array([1.0, 1.0])
-    numerics.NM_MUMPS_set_problem(M, 1, b)
+    numerics.NM_MUMPS_set_matrix(M)
+    numerics.NM_MUMPS_set_dense_rhs(M, 1, b)
 
     # analysis, factorization, solve.
     numerics.NM_MUMPS(M, 6)


### PR DESCRIPTION
This is the MUMPS part for the sparse rhs case (LU & Cholesky). Note that the result is a dense matrix and it is copied from the mumps_id struct to the input/output B matrix. Only the MUMPS centralized configuration (i.e full matrices on host 0) is used.