### PR TITLE
[numerics,kernel] fix memory leaks in SimpleMatrix

### DIFF
--- a/kernel/src/utils/SiconosAlgebra/SimpleMatrix.cpp
+++ b/kernel/src/utils/SiconosAlgebra/SimpleMatrix.cpp
@@ -419,6 +419,8 @@ SimpleMatrix::~SimpleMatrix()
     delete(mat.Triang);
   else if(_num == Siconos::SYMMETRIC)
     delete(mat.Sym);
+  else if(_num == Siconos::SPARSE_COORDINATE)
+    delete(mat.SparseCoordinate);
   else if(_num == Siconos::SPARSE)
     delete(mat.Sparse);
   else if(_num == Siconos::BANDED)
@@ -436,7 +438,7 @@ void SimpleMatrix::updateNumericsMatrix()
   NumericsMatrix * NM;
   if(_num == DENSE)
   {
-    _numericsMatrix.reset(NM_new(),NM_clear_not_dense); // When we reset, we do not free the matrix0
+    _numericsMatrix.reset(NM_new(),NM_free_not_dense); // When we reset, we do not free the matrix0
                                                         //that is linked to the array of the boost container
     NM = _numericsMatrix.get();
     double * data = (double*)(getArray());
@@ -446,7 +448,7 @@ void SimpleMatrix::updateNumericsMatrix()
   else
   {
     // For all the other cases, we build a sparse matrix and we call numerics for the factorization of a sparse matrix.
-    _numericsMatrix.reset(NM_create(NM_SPARSE, size(0), size(1)),NM_clear);
+    _numericsMatrix.reset(NM_create(NM_SPARSE, size(0), size(1)),NM_free);
     NM = _numericsMatrix.get();
     _numericsMatrix->matrix2->origin = NSM_CSC;
     NM_csc_alloc(NM, nnz());

--- a/kernel/src/utils/SiconosAlgebra/test/SimpleMatrixTest.cpp
+++ b/kernel/src/utils/SiconosAlgebra/test/SimpleMatrixTest.cpp
@@ -3488,7 +3488,7 @@ void SimpleMatrixTest::testFromAndFillCSC()
   NM_csc_alloc(NM_1, Sparse4->nnz());
   Sparse4->fillCSC(NM_csc(NM_1));
   //NM_display(NM_1);  --> Note FP : fails when exiting the function ... To be investigating ...
-
+  NM_1 = NM_free(NM_1);
   std::cout << "End SimpleMatrixTest::testFromAndFillCSC() "<< std::endl;
 
 }

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -560,9 +560,20 @@ void NM_clear(NumericsMatrix* m)
     NM_clear(m->destructible);
     m->destructible = m;
   }
+
 }
 
-void NM_clear_not_dense(NumericsMatrix* m)
+NumericsMatrix*  NM_free(NumericsMatrix* m)
+{
+  assert(m && "NM_free, m == NULL");
+
+  NM_clear(m);
+  free(m);
+  return NULL;
+
+}
+
+void  NM_clear_not_dense(NumericsMatrix* m)
 {
   assert(m && "NM_clear, m == NULL");
 
@@ -571,7 +582,26 @@ void NM_clear_not_dense(NumericsMatrix* m)
   NM_clearSparse(m);
 
   NM_internalData_free(m);
+  /* restore the destructible pointer */
+  if (!NM_destructible(m))
+  {
+    NM_clear(m->destructible);
+    m->destructible = m;
+  }
 }
+
+NumericsMatrix*  NM_free_not_dense(NumericsMatrix* m)
+{
+  assert(m && "NM_free_bot_dense, m == NULL");
+  NM_clear_not_dense(m);
+  free(m);
+  return NULL;
+}
+
+
+
+
+
 
 
 void NM_clear_other_storages(NumericsMatrix* M, int storageType)

--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -304,12 +304,15 @@ extern "C"
    */
   void NM_triplet_alloc(NumericsMatrix* A, CS_INT nzmax);
 
+
   /** Free memory for a NumericsMatrix. Warning: call this function only if you are sure that
       memory has been allocated for the structure in Numerics. This function is assumed that the memory is "owned" by this structure.
       Note that this function does not free m.
       \param m the matrix to be deleted.
    */
+
   void NM_clear(NumericsMatrix* m);
+  NumericsMatrix *  NM_free(NumericsMatrix* m);
 
   /** Free memory for a NumericsMatrix except the dense matrix that is assumed not to be owned.
       Warning: call this function only if you are sure that
@@ -318,7 +321,7 @@ extern "C"
       \param m the matrix to be deleted.
    */
   void NM_clear_not_dense(NumericsMatrix* m);
-
+  NumericsMatrix *  NM_free_not_dense(NumericsMatrix* m);
   /** Free memory for a NumericsMatrix except for a given storage. Warning: call this function only if you are sure that
       memory has been allocated for the structure in Numerics. This function is assumed that the memory is "owned" by this structure.
       Note that this function does not free m.


### PR DESCRIPTION
I tried to fix memory leaks in SimpleMatrix.

The test `testSiconosAlgebra` shows only memory in csxsparse.

