### PR TITLE
[numerics] add N(S)M_version_copy functions, should fix #429

### DIFF
--- a/numerics/src/tools/NumericsMatrix.h
+++ b/numerics/src/tools/NumericsMatrix.h
@@ -153,6 +153,11 @@ extern "C"
   RawNumericsMatrix* NM_create_from_filename(const char *filename);
   RawNumericsMatrix* NM_create_from_file(FILE *file);
 
+  /** Copy NumericsMatrix version.
+   * \param[in] A a NumericsMatrix
+   * \param[in,out] B a NumericsMatrix
+   */
+  void NM_version_copy(const NumericsMatrix* const A, NumericsMatrix* B);
 
   /** Copy a NumericsMatrix inside another NumericsMatrix (deep).
    *  Reallocations are performed if B cannot hold a copy of A

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -247,7 +247,34 @@ NumericsSparseMatrix* NSM_clear(NumericsSparseMatrix* A)
   return NULL;
 }
 
-
+void NSM_version_copy(const NumericsSparseMatrix* const A, NumericsSparseMatrix* B)
+{
+  assert(A);
+  assert(B);
+  switch(A->origin)
+  {
+  case NSM_TRIPLET:
+  {
+    NSM_set_version(B, NSM_TRIPLET, NSM_version(A, NSM_TRIPLET));
+    break;
+  }
+  case NSM_HALF_TRIPLET:
+  {
+    NSM_set_version(B, NSM_HALF_TRIPLET, NSM_version(A, NSM_HALF_TRIPLET));
+    break;
+  }
+  case NSM_CSR:
+  {
+    NSM_set_version(B, NSM_CSR, NSM_version(A, NSM_CSR));
+    break;
+  }
+  case NSM_CSC:
+  {
+    NSM_set_version(B, NSM_CSC, NSM_version(B, NSM_CSC));
+    break;
+  }
+  }
+}
 
 
 void NSM_copy(NumericsSparseMatrix* A, NumericsSparseMatrix* B)

--- a/numerics/src/tools/NumericsSparseMatrix.h
+++ b/numerics/src/tools/NumericsSparseMatrix.h
@@ -120,6 +120,13 @@ extern "C"
    */
   NumericsSparseMatrix* NSM_clear(NumericsSparseMatrix* A);
 
+  /** Copy NumericsSparseMatrix version.
+   * \param A a NumericsSparseMatrix
+   * \param B a NumericsSparseMatrix
+   */
+  void NSM_version_copy(const NumericsSparseMatrix* const A,
+                        NumericsSparseMatrix* B);
+
   /** Copy a NumericsSparseMatrix.
    * \param A a NumericsSparseMatrix
    * \param B a NumericsSparseMatrix


### PR DESCRIPTION
This adds NM_version_copy and NSM_version_copy in order to avoid a full NM_copy. It should fix #429.