### PR TITLE
[mechanics] add BodyShapeRecord as an attempt of unique pointer in Contact*R classes

### DIFF
--- a/mechanics/src/MechanicsFwd.hpp
+++ b/mechanics/src/MechanicsFwd.hpp
@@ -75,11 +75,12 @@
   REGISTER(SiconosMesh)                         \
   REGISTER(SiconosHeightMap)                    \
   REGISTER(SiconosDisk)                         \
-  REGISTER(SiconosBox2d)                         \
+  REGISTER(SiconosBox2d)                        \
   REGISTER(SiconosConvexHull2d)                  \
-  REGISTER(SiconosCollisionQueryResult)         \
+  REGISTER(SiconosCollisionQueryResult)          \
   REGISTER(SiconosCollisionManager)             \
-  REGISTER(SiconosBulletCollisionManager)
+  REGISTER(SiconosBulletCollisionManager)       \
+  REGISTER(BodyShapeRecord)
 
 #include <SiconosVisitables.hpp>
 

--- a/mechanics/src/collision/BodyShapeRecord.hpp
+++ b/mechanics/src/collision/BodyShapeRecord.hpp
@@ -1,0 +1,53 @@
+/* Siconos is a program dedicated to modeling, simulation and control
+ * of non smooth dynamical systems.
+ *
+ * Copyright 2021 INRIA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/*! \file BodyShapeRecord.hpp
+  \brief Definition of an abstract Body shape record
+  The objective of this class is to keep associate ds and static body woth the shape
+in a contactor.
+*/
+
+
+#ifndef BodyShapeRecord_h
+#define BodyShapeRecord_h
+
+
+// We need to maintain a record associating each body with a shape,
+// contactor, and collision object for each shape type.  We also need
+// to access generic shape stuff (group, margin) by a pointer from the
+// collision callback, so we need a record base class.
+class BodyShapeRecord
+{
+public:
+  BodyShapeRecord(SP::SiconosVector b, SP::SecondOrderDS d, SP::SiconosShape sh,
+                  SP::SiconosContactor con, SP::StaticBody staticCSR)
+    : base(b), ds(d), sshape(sh), contactor(con), staticBody(staticCSR),
+      shape_version(sh->version()) {}
+  virtual ~BodyShapeRecord() {}
+
+  SP::SiconosVector base;
+  SP::SecondOrderDS ds;
+  SP::SiconosShape sshape;
+  SP::SiconosContactor contactor;
+  unsigned int shape_version;
+  SP::StaticBody staticBody;
+
+  VIRTUAL_ACCEPT_VISITORS();
+};
+
+#endif /* BodyShapeRecord_h */

--- a/mechanics/src/collision/Contact2d3DR.hpp
+++ b/mechanics/src/collision/Contact2d3DR.hpp
@@ -36,11 +36,9 @@ public:
 
 
   /* For users that may require extra information about contacts. */
-  SP::SiconosVector base[2];
-  SP::SiconosShape shape[2];
-  SP::SiconosContactor contactor[2];
-  SP::RigidBody2dDS ds[2];
-  SP::StaticBody staticBody[1];
+  SP::BodyShapeRecord bodyShapeRecordA;
+  SP::BodyShapeRecord bodyShapeRecordB;
+
 
   // /** to compute the output y = h(q,z) of the Relation
   //     \param q coordinates of the dynamical systems involved in the relation

--- a/mechanics/src/collision/Contact2dR.hpp
+++ b/mechanics/src/collision/Contact2dR.hpp
@@ -36,13 +36,10 @@ public:
   /**/
   virtual ~Contact2dR() = default;
 
-
   /* For users that may require extra information about contacts. */
-  SP::SiconosVector base[2];
-  SP::SiconosShape shape[2];
-  SP::SiconosContactor contactor[2];
-  SP::RigidBody2dDS ds[2];
-  SP::StaticBody staticBody[1];
+  SP::BodyShapeRecord bodyShapeRecordA;
+  SP::BodyShapeRecord bodyShapeRecordB;
+
 
   // /** to compute the output y = h(q,z) of the Relation
   //     \param q coordinates of the dynamical systems involved in the relation

--- a/mechanics/src/collision/Contact5DR.hpp
+++ b/mechanics/src/collision/Contact5DR.hpp
@@ -34,11 +34,9 @@ public:
   Contact5DR();
 
   /* For users that may require extra information about contacts. */
-  SP::SiconosVector base[2];
-  SP::SiconosShape shape[2];
-  SP::SiconosContactor contactor[2];
-  SP::RigidBodyDS ds[2];
-  SP::StaticBody staticBody[1];
+  SP::BodyShapeRecord bodyShapeRecordA;
+  SP::BodyShapeRecord bodyShapeRecordB;
+
 
   /** to compute the output y = h(t,q) of the Relation
       \param time current time value

--- a/mechanics/src/collision/ContactR.cpp
+++ b/mechanics/src/collision/ContactR.cpp
@@ -64,9 +64,12 @@ void ContactR::updateContactPoints(const SiconosVector& pos1,
 void ContactR::display() const
 {
   std::cout << "ContactR display()" << std::endl;
-  std::cout << "&staticBody[0]" << &staticBody[0] << std::endl;
-  if (staticBody[0])
+  if (bodyShapeRecordA)
   {
-    std::cout << "staticBody[0]->number : " << staticBody[0]->number << std::endl;
+    std::cout << "bodyShapeRecordA : " << bodyShapeRecordA << std::endl;
+  }
+  if (bodyShapeRecordB)
+  {
+    std::cout << "bodyShapeRecordB : " << bodyShapeRecordB << std::endl;
   }
 }

--- a/mechanics/src/collision/ContactR.hpp
+++ b/mechanics/src/collision/ContactR.hpp
@@ -24,6 +24,7 @@
 #include "NewtonEuler3DR.hpp"
 #include "StaticBody.hpp"
 
+
 class ContactR : public NewtonEuler3DR
 {
 private:
@@ -35,11 +36,8 @@ public:
   ContactR();
 
   /* For users that may require extra information about contacts. */
-  SP::SiconosVector base[2];
-  SP::SiconosShape shape[2];
-  SP::SiconosContactor contactor[2];
-  SP::RigidBodyDS ds[2];
-  SP::StaticBody staticBody[1];
+  SP::BodyShapeRecord bodyShapeRecordA;
+  SP::BodyShapeRecord bodyShapeRecordB;
 
   /** to compute the output y = h(t,q,z) of the Relation
       \param time current time value

--- a/mechanics/swig/mechanics/collision/base.i
+++ b/mechanics/swig/mechanics/collision/base.i
@@ -38,10 +38,13 @@ PY_FULL_REGISTER(ContactR, Mechanics);
 PY_FULL_REGISTER(RigidBodyDS, Mechanics);
 PY_FULL_REGISTER(Contact2dR, Mechanics);
 PY_FULL_REGISTER(Contact2d3DR, Mechanics);
+PY_FULL_REGISTER(Contact5DR, Mechanics);
 PY_FULL_REGISTER(RigidBody2dDS, Mechanics);
 PY_FULL_REGISTER(SiconosCollisionQueryResult, Mechanics);
 PY_FULL_REGISTER(SiconosCollisionManager, Mechanics);
 PY_FULL_REGISTER(StaticBody, Mechanics);
+
+PY_FULL_REGISTER(BodyShapeRecord, Mechanics);
 
 %inline
 {
@@ -49,5 +52,16 @@ PY_FULL_REGISTER(StaticBody, Mechanics);
   {
     return std::dynamic_pointer_cast<ContactR>(rel);
   };
-
+  SP::Contact2dR cast_Contact2dR(SP::Relation rel)
+  {
+    return std::dynamic_pointer_cast<Contact2dR>(rel);
+  };
+  SP::Contact2d3DR cast_Contact2d3DR(SP::Relation rel)
+  {
+    return std::dynamic_pointer_cast<Contact2d3DR>(rel);
+  };
+  SP::Contact5DR cast_Contact5DR(SP::Relation rel)
+  {
+    return std::dynamic_pointer_cast<Contact5DR>(rel);
+  };
 }


### PR DESCRIPTION
This idea of this PR is to provide a common BodyShapeRecord class for users that needs extra information about contactor in a relation.