### PR TITLE
[numerics] add a default case for N(S)M_version_copy

### DIFF
--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -2745,7 +2745,11 @@ void NM_version_copy(const NumericsMatrix* const A, NumericsMatrix* B)
     NSM_version_copy(A->matrix2, B->matrix2);
     break;
   }
+  default:
+    numerics_error("NM_version_copy", "unknown id");
+    return 0;
   }
+  assert (false);
 }
 
 void NM_copy(const NumericsMatrix* const A, NumericsMatrix* B)

--- a/numerics/src/tools/NumericsMatrix.c
+++ b/numerics/src/tools/NumericsMatrix.c
@@ -2746,10 +2746,11 @@ void NM_version_copy(const NumericsMatrix* const A, NumericsMatrix* B)
     break;
   }
   default:
+  {
     numerics_error("NM_version_copy", "unknown id");
-    return 0;
   }
   assert (false);
+  }
 }
 
 void NM_copy(const NumericsMatrix* const A, NumericsMatrix* B)

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -274,10 +274,11 @@ void NSM_version_copy(const NumericsSparseMatrix* const A, NumericsSparseMatrix*
     break;
   }
   default:
+  {
     numerics_error("NSM_version_copy", "unknown id");
-    return 0;
   }
   assert (false);
+  }
 }
 
 void NSM_copy(NumericsSparseMatrix* A, NumericsSparseMatrix* B)

--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -273,9 +273,12 @@ void NSM_version_copy(const NumericsSparseMatrix* const A, NumericsSparseMatrix*
     NSM_set_version(B, NSM_CSC, NSM_version(B, NSM_CSC));
     break;
   }
+  default:
+    numerics_error("NSM_version_copy", "unknown id");
+    return 0;
   }
+  assert (false);
 }
-
 
 void NSM_copy(NumericsSparseMatrix* A, NumericsSparseMatrix* B)
 {


### PR DESCRIPTION
This prevents some undefined behavior and avoids warnings about the switch statements in the 2 new functions.