### PR TITLE
[mechanics] Try to avoid contact with (internal) edges of heightmap

### DIFF
--- a/cmake/PythonInstallSetup.cmake
+++ b/cmake/PythonInstallSetup.cmake
@@ -65,7 +65,7 @@ function(set_python_install_path)
     # -- PY_INSTALL_DIR 
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
       "import site; print(site.ENABLE_USER_SITE)" OUTPUT_VARIABLE ENABLE_USER_SITE)
-    string(STRIP ${ENABLE_USER} ENABLE_USER)
+    string(STRIP ${ENABLE_USER_SITE} ENABLE_USER_SITE)
 
     if(ENABLE_USER_SITE)
       execute_process(COMMAND ${PYTHON_EXECUTABLE} -c

--- a/mechanics/src/collision/bullet/BulletSiconosFwd.hpp
+++ b/mechanics/src/collision/bullet/BulletSiconosFwd.hpp
@@ -54,6 +54,9 @@ DEFINE_SPTR(btConvexShape);
 DEFINE_SPTR(btCollisionObject);
 DEFINE_SAPTR(btCollisionObject);
 
+DEFINE_SPTR(btCollisionObjectWrapper);
+
+
 DEFINE_SPTR(btCollisionWorld);
 DEFINE_SPTR(btDefaultCollisionConfiguration);
 DEFINE_SPTR(btCollisionDispatcher);

--- a/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
+++ b/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
@@ -2216,6 +2216,7 @@ static void siconosBulletAdjustInternalEdgeContacts(btManifoldPoint& cp, const b
 		const btTriangleShape* tri_shape = static_cast<const btTriangleShape*>(colObj0Wrap->getCollisionShape());
 		btVector3 tri_normal;
 		tri_shape->calcNormal(tri_normal);
+
 		newNormal = tri_normal;
 		//					cp.m_distance1 = cp.m_distance1 * newNormal.dot(cp.m_normalWorldOnB);
     btVector3 oldNormal =  	cp.m_normalWorldOnB;
@@ -2224,21 +2225,34 @@ static void siconosBulletAdjustInternalEdgeContacts(btManifoldPoint& cp, const b
     //printf("new normal %e\t%e\t%e\n", newNormal.x(),  newNormal.y(), newNormal.z());
     //printf("cp.m_distance1 = %e\n", cp.m_distance1 );
 
+
+    // Option 1 - we test if the normal are similar or not before changing the normal
+
+    // btScalar cosine =  oldNormal.dot(newNormal);
+    // //printf("cosine %e\n", cosine);
+    // if (cosine < 0.0)
+    // {
+    //   newNormal = -1.0*tri_normal;
+    //   cosine =  oldNormal.dot(newNormal);
+    // }
+    // //btScalar diff  = oldNormal.distance(newNormal);
+    // //printf("diff %e\n", diff);
+    // if ((1.0 - cosine) > 3e-03 ) // around 5 degrees
+    // {
+    //   //printf("--------------------------------------> change edge  normal to triangle normal\n");
+    //   cp.m_normalWorldOnB = newNormal;
+    // }
+    // else return;
+
+    // Option 2 - we take in any cases the normal to the triangle face
+
     btScalar cosine =  oldNormal.dot(newNormal);
-    //printf("cosine %e\n", cosine);
     if (cosine < 0.0)
     {
       newNormal = -1.0*tri_normal;
-      cosine =  oldNormal.dot(newNormal);
     }
-    //btScalar diff  = oldNormal.distance(newNormal);
-    //printf("diff %e\n", diff);
-    if ((1.0 - cosine) > 3e-03 ) // around 5 degrees
-    {
-      //printf("--------------------------------------> change edge  normal to triangle normal\n");
-      cp.m_normalWorldOnB = newNormal;
-    }
-    else return;
+    cp.m_normalWorldOnB = newNormal;
+
 
 		// Reproject collision point along normal. (what about cp.m_distance1?)
 		cp.m_positionWorldOnB = cp.m_positionWorldOnA - cp.m_normalWorldOnB * cp.m_distance1;

--- a/mechanics/src/collision/bullet/SiconosBulletCollisionManager.hpp
+++ b/mechanics/src/collision/bullet/SiconosBulletCollisionManager.hpp
@@ -99,6 +99,10 @@ protected:
 
   // callback for contact point removal, and a global for context
   static bool bulletContactClear(void* userPersistentData);
+
+  // callback to modify the contact point when it has just been added in the manifold.
+  static bool bulletContactAddedCallback(btManifoldPoint& cp, const btCollisionObjectWrapper* colObj0Wrap, int partId0, int index0,
+                                         const btCollisionObjectWrapper* colObj1Wrap, int partId1, int index1);
   static Simulation *gSimulation;
 
 public:


### PR DESCRIPTION
	    When bodies slide on heightmap that is nearly flat, the contact with edges
	    of the triangular discretization of the heightmap generate artificial normals.

	    To avoid this issue we call the gContactAddedCallback, and we use the normal to faces
	    of the triangle only.

	    Should also be used for STL meshes.