### PR TITLE
[io] h5py: direct check of attributes instead of version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,6 +38,7 @@ jobs:
         liblpsolve55-dev \
         python3 \
         python3-packaging \
+        python3-h5py \
         libpython3-dev \
         libcppunit-dev \
         libbullet-dev \

--- a/io/swig/io/mechanics_hdf5.py
+++ b/io/swig/io/mechanics_hdf5.py
@@ -5,10 +5,11 @@ from math import cos, sin, asin, atan2
 import numpy as np
 import h5py
 ## fix compatibility with h5py version
-if (h5py.version.version_tuple.major >=3 ):
+if hasattr(h5py, 'vlen_dtype'):
     h5py_vlen_dtype = h5py.vlen_dtype
-else:
+elif hasattr(h5py, 'new_vlen'):
     h5py_vlen_dtype = h5py.new_vlen
+
 
 import pickle
 import tempfile

--- a/io/swig/io/mechanics_run.py
+++ b/io/swig/io/mechanics_run.py
@@ -12,9 +12,9 @@ from scipy import constants
 import numpy as np
 import h5py
 ## fix compatibility with h5py version
-if (h5py.version.version_tuple.major >=3 ):
+if hasattr(h5py, 'vlen_dtype'):
     h5py_vlen_dtype = h5py.vlen_dtype
-else:
+elif hasattr(h5py, 'new_vlen'):
     h5py_vlen_dtype = h5py.new_vlen
 
 import bisect

--- a/io/swig/io/mechanics_run.py
+++ b/io/swig/io/mechanics_run.py
@@ -127,12 +127,6 @@ def setup_default_classes():
     default_simulation_class = TimeStepping
     default_body_class = RigidBodyDS
     if backend == 'bullet':
-        if not have_bullet:
-            msg = '[mechanics_run] WARNING: Bullet is the collision backend'
-            msg += 'but the module siconos.mechanics.collision.bullet'
-            msg += 'can not be imported. Check your installation.'
-            print(msg)
-
         def m(bullet_options):
             if bullet_options is None:
                 bullet_options = SiconosBulletOptions()
@@ -2756,7 +2750,7 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
             msg += '                             with  bullet_options.perturbationIterations and bullet_options.minimumPointsPerturbationThreshold.'
             raise RuntimeError(msg)
 
-        if  bullet_options is None:
+        if bullet_options is None and have_bullet:
             bullet_options = SiconosBulletOptions()
             if multipoints_iterations :
                 bullet_options.perturbationIterations = 3 * multipoints_iterations
@@ -2764,7 +2758,8 @@ class MechanicsHdf5Runner(siconos.io.mechanics_hdf5.MechanicsHdf5):
                     3 * multipoints_iterations
 
         # MB: this may be in conflict with 'dimension' attribute
-        if bullet_options.dimension == SICONOS_BULLET_2D:
+        if bullet_options is not None and \
+           bullet_options.dimension == SICONOS_BULLET_2D:
             self._dimension = 2
         else:
             if (self._out.attrs.get('dimension', None) is None):


### PR DESCRIPTION

This  should fix https://github.com/siconos/siconos/runs/4559708594?check_suite_focus=true

which is due to a wrong decision made on h5py version.
With python, it is safer to check the existence of attributes with ``hasattr``.