### PR TITLE
Fix size in fclib interface

### DIFF
--- a/numerics/src/FrictionContact/fclib_interface.c
+++ b/numerics/src/FrictionContact/fclib_interface.c
@@ -273,12 +273,8 @@ int frictionContact_fclib_write(FrictionContactProblem* problem, char * title, c
   fclib_problem->info->description = description;
   fclib_problem->info->math_info = mathInfo;
 
-  fclib_problem->W = (struct fclib_matrix*)malloc(sizeof(struct fclib_matrix));
   fclib_problem->R = NULL;
   fclib_problem->V = NULL;
-
-  fclib_problem->W->m = problem->M->size0;
-  fclib_problem->W->n = problem->M->size1;
 
   CSparseMatrix * spmat = NM_triplet(problem->M);
 

--- a/numerics/src/FrictionContact/fclib_interface.h
+++ b/numerics/src/FrictionContact/fclib_interface.h
@@ -43,6 +43,11 @@ extern "C"
 
   FrictionContactProblem* frictionContact_fclib_read(const char *path);
 
+  int frictionContact_fclib_write_csr(FrictionContactProblem* problem,
+                                      char * title, char * description,
+                                      char * mathInfo,
+                                      const char *path, int ndof);
+  
   int frictionContact_fclib_write(FrictionContactProblem* problem,
                                   char * title, char * description,
                                   char * mathInfo,


### PR DESCRIPTION
1) fix sizes in fclib interfaces for triplet matrices
	   We output only values up to nz and we set nzmax to nz
 	   There  is no interest to save in fclib file values from nz to nzmax
2) use NM_triplet by default for writing problem in fclib_local format
	   (simplify code)