### PR TITLE
Simplify bulletR

### DIFF
--- a/kernel/src/modelingTools/NewtonEuler1DR.cpp
+++ b/kernel/src/modelingTools/NewtonEuler1DR.cpp
@@ -274,6 +274,15 @@ double NewtonEuler1DR::distance() const
 void NewtonEuler1DR::computeh(double time, const BlockVector& q0,
                               SiconosVector &y)
 {
+  // Contact points and normal are stored in absolute coordinates.
+  // nothing to do here
+
+  NewtonEulerR::computeh(time, q0, y);
+}
+
+void NewtonEuler1DR::computehFromRelativeContactPoints(double time, const BlockVector& q0,
+                              SiconosVector &y)
+{
   // Contact points and normal are stored as relative to q1 and q2, if
   // no q2 then pc2 and normal are absolute.
 

--- a/kernel/src/modelingTools/NewtonEuler1DR.hpp
+++ b/kernel/src/modelingTools/NewtonEuler1DR.hpp
@@ -31,7 +31,7 @@
    the method computeh, by setting the member pc1, pc2, nc and y.  The
    matrix jachq is used both for the building of the OSNSP (with T)
    and for the predictor of activation of deactivation of the Interaction.
-   
+
 */
 class NewtonEuler1DR : public NewtonEulerR {
 protected:
@@ -89,7 +89,7 @@ protected:
 
   /** Set the coordinates of inside normal vector at the contact point.
    *  Must only be done in a computeh() override.
-   * 
+   *
    *  \param nnc new coordinates
    */
   void setnc(SP::SiconosVector nnc) { _Nc = nnc; };
@@ -101,7 +101,7 @@ private:
 public:
   /** V.A. boolean _isOnCOntact ?? Why is it public members ?
    *  seems parametrize the projection algorithm
-   *  the projection is done on the surface  \f$ y=0 \f$  or on  \f$ y \geq 0 \f$ 
+   *  the projection is done on the surface  \f$ y=0 \f$  or on  \f$ y \geq 0 \f$
    */
   bool _isOnContact = false;
 
@@ -133,14 +133,23 @@ public:
    */
   void computeJachqT(Interaction &inter, SP::BlockVector q0) override;
 
-  /** 
+  /**
       to compute the output y = h(t,q,z) of the Relation
-      
+
       \param time current time value
       \param q coordinates of the dynamical systems involved in the relation
       \param y the resulting vector
   */
   void computeh(double time, const BlockVector &q0, SiconosVector &y) override;
+
+  /**
+      to compute the output y = h(t,q,z) of the Relation
+      with the relative contact points
+      \param time current time value
+      \param q coordinates of the dynamical systems involved in the relation
+      \param y the resulting vector
+   */
+  void computehFromRelativeContactPoints(double time, const BlockVector &q0, SiconosVector &y);
 
   /** Return the distance between pc1 and pc, with sign according to normal */
   double distance() const;
@@ -162,14 +171,14 @@ public:
 
   /** Set the coordinates of second contact point in ds2 frame
    *  It will be used to compute _Pc2 during computeh().
-   * 
+   *
    *  \param npc new coordinates
    */
   void setRelPc2(SP::SiconosVector npc) { _relPc2 = npc; };
 
   /** Set the coordinates of inside normal vector at the contact point in ds2
    *  frame. It will be used to compute _Nc during computeh().
-   *  
+   *
    *  \param nnc new coordinates
    */
   void setRelNc(SP::SiconosVector nnc) { _relNc = nnc; };

--- a/mechanics/src/collision/bullet/Bullet5DR.cpp
+++ b/mechanics/src/collision/bullet/Bullet5DR.cpp
@@ -54,75 +54,23 @@ Bullet5DR::Bullet5DR()
 {
 }
 
-void Bullet5DR::updateContactPointsFromManifoldPoint(const btPersistentManifold& manifold,
-    const btManifoldPoint& point,
-    bool flip, double scaling,
-    SP::NewtonEulerDS ds1,
-    SP::NewtonEulerDS ds2)
+void Bullet5DR::updateContactPointsFromManifoldPoint(
+  const btPersistentManifold& manifold,
+  const btManifoldPoint& point,
+  bool flip, double scaling,
+  SP::NewtonEulerDS ds1,
+  SP::NewtonEulerDS ds2)
 {
-  // Get new world positions of contact points and calculate relative
-  // to ds1 and ds2
-
-  ::boost::math::quaternion<double> rq1, rq2, posa;
-  ::boost::math::quaternion<double> pq1, pq2, posb;
-  copyQuatPos(*ds1->q(), pq1);
-  copyQuatRot(*ds1->q(), rq1);
-  if(ds2)
+  if (flip)
   {
-    copyQuatPos(*ds2->q(), pq2);
-    copyQuatRot(*ds2->q(), rq2);
-  }
-
-  copyQuatPos(point.getPositionWorldOnA() / scaling, posa);
-  copyQuatPos(point.getPositionWorldOnB() / scaling, posb);
-
-  if(flip)
-  {
-    ::boost::math::quaternion<double> tmp = posa;
-    posa = posb;
-    posb = tmp;
-  }
-
-  SiconosVector va(3), vb(3), vn(3);
-  if(flip)
-  {
-    copyQuatPos((1.0/rq1) * (posa - pq1) * rq1, va);
-    if(ds2)
-      copyQuatPos((1.0/rq2) * (posb - pq2) * rq2, vb);
-    else
-    {
-      // If no body2, position is relative to 0,0,0
-      copyBtVector3(point.getPositionWorldOnA() / scaling, vb);
-    }
+    copyBtVector3(-1.0*point.m_normalWorldOnB, *_Nc);
+    copyBtVector3(point.getPositionWorldOnA() / scaling, *_Pc2);
+    copyBtVector3(point.getPositionWorldOnB() / scaling, *_Pc1);
   }
   else
   {
-    copyQuatPos((1.0/rq1) * (posa - pq1) * rq1, va);
-    if(ds2)
-      copyQuatPos((1.0/rq2) * (posb - pq2) * rq2, vb);
-    else
-    {
-      // If no body2, position is relative to 0,0,0
-      copyBtVector3(point.getPositionWorldOnB() / scaling, vb);
-    }
+    copyBtVector3(point.m_normalWorldOnB, *_Nc);
+    copyBtVector3(point.getPositionWorldOnA() / scaling, *_Pc1);
+    copyBtVector3(point.getPositionWorldOnB() / scaling, *_Pc2);
   }
-
-  // Get new normal
-  if(ds2)
-  {
-    btQuaternion qn(point.m_normalWorldOnB.x(),
-                    point.m_normalWorldOnB.y(),
-                    point.m_normalWorldOnB.z(), 0);
-    btQuaternion qb1 = manifold.getBody1()->getWorldTransform().getRotation();
-    // un-rotate normal into body1 frame
-    qn = qb1.inverse() * qn * qb1;
-    vn(0) = qn.x();
-    vn(1) = qn.y();
-    vn(2) = qn.z();
-    vn = vn/vn.norm2();
-  }
-  else
-    copyBtVector3(point.m_normalWorldOnB, vn);
-
-  Contact5DR::updateContactPoints(va, vb, vn*(flip?-1:1));
 }

--- a/mechanics/src/collision/bullet/BulletR.cpp
+++ b/mechanics/src/collision/bullet/BulletR.cpp
@@ -56,99 +56,27 @@ BulletR::BulletR()
 {
 }
 
-void BulletR::updateContactPointsFromManifoldPoint(const btPersistentManifold& manifold,
-    const btManifoldPoint& point,
-    bool flip, double scaling,
-    SP::NewtonEulerDS ds1,
-    SP::NewtonEulerDS ds2)
+void BulletR::updateContactPointsFromManifoldPoint(
+  const btPersistentManifold& manifold,
+  const btManifoldPoint& point,
+  bool flip, double scaling,
+  SP::NewtonEulerDS ds1,
+  SP::NewtonEulerDS ds2)
 {
-  // Get new world positions of contact points and calculate relative
-  // to ds1 and ds2
-
-  ::boost::math::quaternion<double> rq1, rq2, posa;
-  ::boost::math::quaternion<double> pq1, pq2, posb;
-
-  copyQuatPos(*ds1->q(), pq1);
-  copyQuatRot(*ds1->q(), rq1);
-
-  if(ds2)
+  if (flip)
   {
-    copyQuatPos(*ds2->q(), pq2);
-    copyQuatRot(*ds2->q(), rq2);
-  }
-
-  copyQuatPos(point.getPositionWorldOnA() / scaling, posa);
-  copyQuatPos(point.getPositionWorldOnB() / scaling, posb);
-
-  if(flip)
-  {
-    ::boost::math::quaternion<double> tmp = posa;
-    posa = posb;
-    posb = tmp;
-  }
-
-  SiconosVector va(3), vb(3), vn(3);
-  if(flip)
-  {
-    copyQuatPos((1.0/rq1) * (posa - pq1) * rq1, va);
-    if(ds2)
-      copyQuatPos((1.0/rq2) * (posb - pq2) * rq2, vb);
-    else
-    {
-      // If no body2, position is relative to 0,0,0
-      copyBtVector3(point.getPositionWorldOnA() / scaling, vb);
-    }
+    copyBtVector3(-1.0*point.m_normalWorldOnB, *_Nc);
+    copyBtVector3(point.getPositionWorldOnA() / scaling, *_Pc2);
+    copyBtVector3(point.getPositionWorldOnB() / scaling, *_Pc1);
   }
   else
   {
-    copyQuatPos((1.0/rq1) * (posa - pq1) * rq1, va);
-    if(ds2)
-      copyQuatPos((1.0/rq2) * (posb - pq2) * rq2, vb);
-    else
-    {
-      // If no body2, position is relative to 0,0,0
-      copyBtVector3(point.getPositionWorldOnB() / scaling, vb);
-    }
+    copyBtVector3(point.m_normalWorldOnB, *_Nc);
+    copyBtVector3(point.getPositionWorldOnA() / scaling, *_Pc1);
+    copyBtVector3(point.getPositionWorldOnB() / scaling, *_Pc2);
   }
-
-  // Get new normal
-  if(ds2)
-  {
-
-
-    btQuaternion qn(point.m_normalWorldOnB.x(),
-                    point.m_normalWorldOnB.y(),
-                    point.m_normalWorldOnB.z(), 0);
-
-    // get world transform of the body 1 (corresponds to Body B)
-    btQuaternion qb1 = manifold.getBody1()->getWorldTransform().getRotation();
-
-    // un-rotate normal into body1 frame
-    qn = qb1.inverse() * qn * qb1;
-
-    // Apply offset
-    if (bodyShapeRecordB->contactor->offset) // VA: Are we sure that is is always bodyShapeRecordB->contactor->offset ?
-    {
-      const SiconosVector& offset   = *bodyShapeRecordB->contactor->offset;
-      btQuaternion roffset(offset(4), offset(5), offset(6), offset(3));
-      qn = roffset* qn * roffset.inverse();
-    }
-
-    vn(0) = qn.x();
-    vn(1) = qn.y();
-    vn(2) = qn.z();
-    vn = vn/vn.norm2();
-
-
-  }
-  else
-    copyBtVector3(point.m_normalWorldOnB, vn);
-
-
-
-
-  ContactR::updateContactPoints(va, vb, vn*(flip?-1:1));
 }
+
 void BulletR::display() const
 {
   std::cout << "BulletR display()" << std::endl;

--- a/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
+++ b/mechanics/src/collision/bullet/SiconosBulletCollisionManager.cpp
@@ -145,6 +145,11 @@ DEFINE_SPTR(UpdateShapeVisitor)
 #pragma GCC diagnostic pop
 #endif
 
+// This value is compared to the initial distance computed
+// at the creation of the interaction
+// if distance < - WARNING_TOLERANCE_AT_CREATION_INTERACTION
+// a warning is raised. 
+#define WARNING_TOLERANCE_AT_CREATION_INTERACTION 1e-5
 
 // Comment this to try un-queued static contactor behaviour
 #define QUEUE_STATIC_CONTACTORS 1
@@ -2835,7 +2840,7 @@ void SiconosBulletCollisionManager::updateInteractions(SP::Simulation simulation
           // We wish to be sure that no Interactions are created without
           // sufficient warning before contact.  TODO: Replace with exception or
           // flag.
-          if(rel->distance() < 0.0)
+          if(rel->distance() < - WARNING_TOLERANCE_AT_CREATION_INTERACTION)
           {
             DEBUG_PRINTF("SiconosBulletCollisionManager :: Interactions must be created with positive "
                          "distance (%f).\n", rel->distance());
@@ -2875,7 +2880,7 @@ void SiconosBulletCollisionManager::updateInteractions(SP::Simulation simulation
           // We wish to be sure that no Interactions are created without
           // sufficient warning before contact.  TODO: Replace with exception or
           // flag.
-          if(rel->distance() < 0.0)
+          if(rel->distance() <  - WARNING_TOLERANCE_AT_CREATION_INTERACTION)
           {
             DEBUG_PRINTF("SiconosBulletCollisionManager :: Interactions must be created with positive "
                          "distance (%f).\n", rel->distance());
@@ -2919,7 +2924,7 @@ void SiconosBulletCollisionManager::updateInteractions(SP::Simulation simulation
           // We wish to be sure that no Interactions are created without
           // sufficient warning before contact.  TODO: Replace with exception or
           // flag.
-          if(rel->distance() < 0.0)
+          if(rel->distance() <  - WARNING_TOLERANCE_AT_CREATION_INTERACTION)
           {
             DEBUG_PRINTF("Interactions must be created with positive "
                          "distance (%f).\n", rel->distance());
@@ -2963,7 +2968,7 @@ void SiconosBulletCollisionManager::updateInteractions(SP::Simulation simulation
           // We wish to be sure that no Interactions are created without
           // sufficient warning before contact.  TODO: Replace with exception or
           // flag.
-          if(rel->distance() < 0.0)
+          if(rel->distance() <  - WARNING_TOLERANCE_AT_CREATION_INTERACTION)
           {
             DEBUG_PRINTF("SiconosBulletCollisionManager :: Interactions must be created with positive "
                          "distance (%f).\n", rel->distance());


### PR DESCRIPTION
Simplify the computation of relations using directly contact points in the absolute frame.
- fix automatically the problem with offset
- more efficient computations.
     
Old computation based on (relative) contacts points in the body-fixed frame are removed.
- The old implementation was motivated by the possibility to update the relative contacts points
  without calling the bullet contact detection. This may cause sometimes instabilities. To be discussed
  in the future if we want to come back to this implementation.