### PR TITLE
[numerics] add initializations for some NumericsMatrix

### DIFF
--- a/numerics/src/GenericMechanical/GMPReduced.c
+++ b/numerics/src/GenericMechanical/GMPReduced.c
@@ -720,6 +720,7 @@ void gmp_as_mlcp(GenericMechanicalProblem* pInProblem, double *reaction, double 
     LinearComplementarityProblem aLCP;
     SolverOptions *aLcpOptions = solver_options_create(SICONOS_LCP_ENUM);
     NumericsMatrix M;
+    NM_null(&M);
     M.storageType = 0;
     M.size0 = Mi_size;
     M.size1 = Mi_size;
@@ -742,6 +743,7 @@ void gmp_as_mlcp(GenericMechanicalProblem* pInProblem, double *reaction, double 
     assert(Me_size >= 0);
     for(size_t i = 0; i < (size_t)Me_size; ++i) reaction[i] = -Qreduced[i];
     NumericsMatrix M;
+    NM_null(&M);
     NM_fill(&M, NM_DENSE, Me_size, Me_size, reducedProb);
     // *info = NM_gesv(&M, reaction, true);
     *info = NM_LU_solve(&M, reaction, 1);
@@ -767,6 +769,7 @@ void gmp_as_mlcp(GenericMechanicalProblem* pInProblem, double *reaction, double 
   aMLCP.b = 0;
   aMLCP.q = Qreduced;
   NumericsMatrix M;
+  NM_null(&M);
   M.storageType = 0;
   M.size0 = Mi_size + Me_size;
   M.size1 = Mi_size + Me_size;


### PR DESCRIPTION
When ```NumericsMatrix``` is declared on the stack : ```NumericsMatrix M;```, it then needs to be initialized by
```NM_null(&M);``` otherwise pointers and versions are in some bad state. This should fix #473