### PR TITLE
Work around an issue related to a macro named "I"

### DIFF
--- a/numerics/src/tools/test/SparseMatrix_test.c
+++ b/numerics/src/tools/test/SparseMatrix_test.c
@@ -273,13 +273,13 @@ static int test_CSparseMatrix_spsolve_unit(CSparseMatrix *M )
     printf("problem in spsolve\n");
     return info;
   }
-  CSparseMatrix* I = cs_multiply(M, B);
+  CSparseMatrix* II = cs_multiply(M, B);
   //printf(" M * M^-1:\n");
   //cs_print(I, 0);
 
   CSparseMatrix *Id = cs_compress(b_triplet);
 
-  CSparseMatrix* check = cs_add(I, Id, 1.0, -1.0);
+  CSparseMatrix* check = cs_add(II, Id, 1.0, -1.0);
   //cs_print(check, 0);
 
   double error = cs_norm(check);
@@ -289,7 +289,7 @@ static int test_CSparseMatrix_spsolve_unit(CSparseMatrix *M )
   cs_spfree(B);
   cs_spfree(X);
   CSparseMatrix_free_lu_factors(cs_lu_M);
-  cs_spfree(I);
+  cs_spfree(II);
   cs_spfree(Id);
   cs_spfree(check);
 
@@ -384,13 +384,13 @@ static int test_CSparseMatrix_chol_spsolve_unit(CSparseMatrix *M )
     printf("problem in chol_spsolve\n");
     return info;
   }
-  CSparseMatrix* I = cs_multiply(M, B);
+  CSparseMatrix* II = cs_multiply(M, B);
   //printf(" M * M^-1:\n");
   //cs_print(I, 0);
 
   CSparseMatrix *Id = cs_compress(b_triplet);
 
-  CSparseMatrix* check = cs_add(I, Id, 1.0, -1.0);
+  CSparseMatrix* check = cs_add(II, Id, 1.0, -1.0);
   //cs_print(check, 0);
 
   double error = cs_norm(check);
@@ -399,7 +399,7 @@ static int test_CSparseMatrix_chol_spsolve_unit(CSparseMatrix *M )
   cs_spfree(B);
   cs_spfree(X);
   CSparseMatrix_free_lu_factors(cs_chol_M);
-  cs_spfree(I);
+  cs_spfree(II);
   cs_spfree(Id);
   cs_spfree(check);
 


### PR DESCRIPTION
Dear Siconos team,

Due to an issue related to a macro named "I", Politecnico Di Milano is proposing to rename a variable from "I" to "II". See the following description from Marco Morandini:

```
The failure is because in /usr/local/include/complex.h we have

#define _Complex_I      (__extension__ 1.0iF)

/* Another more descriptive name is `I'.
   XXX Once we have the imaginary support switch this to _Imaginary_I.  */
#undef I
#define I _Complex_I


and in siconos/numerics/src/tools/test/SparseMatrix_test.c there are lines like

  CSparseMatrix* I = cs_multiply(M, B);

If I change these "I" into e.g. "II" (6 lines need to be changed, patch attached) then the build proceeds.
What I don't have clear is why it used to build on the CI machine; perhaps there was an update for the CS sparse version; in

siconos/numerics/src/tools/CSparseMatrix_internal.h

there are these lines,

/* Siconos does not need "complex" part of CXSparse, so avoid
 * compilation C++-related problems with this flag (complex_t vs
 * std::complex). */
#define NCOMPLEX

but, while older csparse had this

#ifndef NCOMPLEX
#include <complex.h>
#define cs_complex_t double _Complex
#endif


in cs.h, the newer version installed on the CI desktop builds the complex stuff unconditionally:
```
Best regards,
Reinhard