### PR TITLE
[numerics] NSM_latest_id + few others out of compilation unit

### DIFF
--- a/numerics/src/tools/NumericsSparseMatrix.c
+++ b/numerics/src/tools/NumericsSparseMatrix.c
@@ -68,10 +68,6 @@ static int sort_indices_struct_cmp(const void *a, const void *b)
 #pragma GCC diagnostic pop
 #endif
 
-version_t NSM_version(const NumericsSparseMatrix* M, NSM_t type)
-{
-  return NDV_value(&(M->versions[type]));
-}
 
 void NSM_set_version(NumericsSparseMatrix* M, NSM_t type,
                      version_t value)
@@ -87,28 +83,7 @@ void NSM_inc_version(NumericsSparseMatrix* M, NSM_t type)
 }
 
 /* internal compare function */
-static inline NSM_t nsm_max(const NumericsSparseMatrix* M,
-                               NSM_t type1,
-                               NSM_t type2)
-{
-  return NSM_version(M, type2) > NSM_version(M, type1) ?
-    type2 : type1;
-}
 
-NSM_t NSM_latest_id(const NumericsSparseMatrix* M)
-{
-  assert(M);
-
-  return (nsm_max(M, nsm_max(M, nsm_max(M, NSM_TRIPLET,
-                                        NSM_HALF_TRIPLET),
-                             NSM_CSC),
-                  NSM_CSR));
-}
-
-version_t NSM_max_version(const NumericsSparseMatrix* M)
-{
-  return NSM_version(M, NSM_latest_id(M));
-}
 
 
 CSparseMatrix* NSM_latest(const NumericsSparseMatrix* M)
@@ -139,16 +114,6 @@ void NSM_reset_versions(NumericsSparseMatrix* M)
   NSM_reset_version(M, NSM_CSC);
   NSM_reset_version(M, NSM_CSR);
 }
-
-void NSM_version_sync(NumericsSparseMatrix* M)
-{
-  if (NSM_max_version(M) > 0)
-  {
-    M->origin = NSM_latest_id(M);
-    assert(NSM_latest(M));
-  }
-}
-
 
 void NSM_null(NumericsSparseMatrix* A)
 {


### PR DESCRIPTION
NSM_latest_id and some other functions about sparse matrix versioning inside numerics appear to be time consuming during computeOneStep for the vkernel (here 2d_sphere_recirculation.py, performance=True, 20000 disks, step ~ 7000 of 10000 timesteps, compactNsearch on gpu, gcc-12)
![Screenshot from 2024-06-17 12-26-07](https://github.com/siconos/siconos/assets/5980800/53431b6a-9aa5-4689-9467-04bb2c4cba9c)

The solution to move them directly in the header file and force the compiler to inline them provides an interesting gain  (time without inlining / time with inlining is around 1.3 in this case and maybe also interesting in the case of bullet simulations) .
On my PC, without inlining:
```bash
./vrun --env-ok --time 'duration: %E' src/siconos/tests/2d_sphere_recirculation.py vnative > 2d_sphere_recirculation_vnative_gpu.log
duration: 29:06.32
```
The same command with inlining gives something like:
```bash
duration: 22:03.04 
```

I did not test with static alone (i.e. without inline keyword), to see if the compiler choose a correct solution by itself, but as the involved code is small it is probably not important. 

This PR is also pushed on gricad : https://gricad-gitlab.univ-grenoble-alpes.fr/bremonma/siconos/-/commits/numerics-inlining

